### PR TITLE
Allow rest base 32 addresses

### DIFF
--- a/src/infrastructure/AccountHttp.ts
+++ b/src/infrastructure/AccountHttp.ts
@@ -113,7 +113,7 @@ export class AccountHttp extends Http implements AccountRepository {
         return new AccountInfo(
             dto.account.version || 1,
             dto.id,
-            Address.createFromEncoded(dto.account.address),
+            DtoMapping.toAddress(dto.account.address),
             UInt64.fromNumericString(dto.account.addressHeight),
             dto.account.publicKey,
             UInt64.fromNumericString(dto.account.publicKeyHeight),

--- a/src/infrastructure/BlockHttp.ts
+++ b/src/infrastructure/BlockHttp.ts
@@ -17,7 +17,6 @@
 import { Observable } from 'rxjs';
 import { BlockInfoDTO, BlockRoutesApi, ImportanceBlockDTO } from 'symbol-openapi-typescript-fetch-client';
 import { DtoMapping } from '../core/utils/DtoMapping';
-import { Address } from '../model/account/Address';
 import { PublicAccount } from '../model/account/PublicAccount';
 import { BlockInfo } from '../model/blockchain/BlockInfo';
 import { BlockType } from '../model/blockchain/BlockType';
@@ -121,7 +120,7 @@ export class BlockHttp extends Http implements BlockRepository {
             dto.block.proofGamma,
             dto.block.proofScalar,
             dto.block.proofVerificationHash,
-            Address.createFromEncoded(dto.block.beneficiaryAddress),
+            DtoMapping.toAddress(dto.block.beneficiaryAddress),
             dto.meta.transactionsCount,
             dto.meta.statementsCount,
         );

--- a/src/infrastructure/HashLockHttp.ts
+++ b/src/infrastructure/HashLockHttp.ts
@@ -17,7 +17,6 @@
 import { Observable } from 'rxjs';
 import { HashLockInfoDTO, HashLockRoutesApi } from 'symbol-openapi-typescript-fetch-client';
 import { DtoMapping } from '../core/utils/DtoMapping';
-import { Address } from '../model/account/Address';
 import { MerkleStateInfo } from '../model/blockchain/MerkleStateInfo';
 import { HashLockInfo } from '../model/lock/HashLockInfo';
 import { MosaicId } from '../model/mosaic/MosaicId';
@@ -100,7 +99,7 @@ export class HashLockHttp extends Http implements HashLockRepository {
         return new HashLockInfo(
             dto.lock.version || 1,
             dto.id,
-            Address.createFromEncoded(dto.lock.ownerAddress),
+            DtoMapping.toAddress(dto.lock.ownerAddress),
             new MosaicId(dto.lock.mosaicId),
             UInt64.fromNumericString(dto.lock.amount),
             UInt64.fromNumericString(dto.lock.endHeight),

--- a/src/infrastructure/Listener.ts
+++ b/src/infrastructure/Listener.ts
@@ -19,7 +19,7 @@ import { catchError, distinctUntilChanged, filter, map, mergeMap, share, switchM
 import { BlockInfoDTO } from 'symbol-openapi-typescript-fetch-client';
 import * as WebSocket from 'ws';
 import { parseObjectProperties } from '../core/format/Utilities';
-import { MultisigChildrenTreeObject, MultisigGraphUtils } from '../core/utils';
+import { DtoMapping, MultisigChildrenTreeObject, MultisigGraphUtils } from '../core/utils';
 import { MultisigAccountInfo, UnresolvedAddress } from '../model';
 import { Address } from '../model/account/Address';
 import { PublicAccount } from '../model/account/PublicAccount';
@@ -36,6 +36,7 @@ import { MultisigHttp } from './MultisigHttp';
 import { MultisigRepository } from './MultisigRepository';
 import { NamespaceRepository } from './NamespaceRepository';
 import { CreateTransactionFromDTO } from './transaction/CreateTransactionFromDTO';
+
 export enum ListenerChannelName {
     block = 'block',
     confirmedAdded = 'confirmedAdded',
@@ -579,7 +580,7 @@ export class Listener implements IListener {
             dto.block.proofGamma,
             dto.block.proofScalar,
             dto.block.proofVerificationHash,
-            dto.block.beneficiaryAddress ? Address.createFromEncoded(dto.block.beneficiaryAddress) : undefined,
+            dto.block.beneficiaryAddress ? DtoMapping.toAddress(dto.block.beneficiaryAddress) : undefined,
         );
     }
 

--- a/src/infrastructure/MetadataHttp.ts
+++ b/src/infrastructure/MetadataHttp.ts
@@ -18,7 +18,6 @@ import { Observable } from 'rxjs';
 import { MetadataInfoDTO, MetadataRoutesApi } from 'symbol-openapi-typescript-fetch-client';
 import { Convert } from '../core/format/Convert';
 import { DtoMapping } from '../core/utils/DtoMapping';
-import { Address } from '../model/account/Address';
 import { MerkleStateInfo } from '../model/blockchain';
 import { Metadata } from '../model/metadata/Metadata';
 import { MetadataEntry } from '../model/metadata/MetadataEntry';
@@ -122,8 +121,8 @@ export class MetadataHttp extends Http implements MetadataRepository {
             new MetadataEntry(
                 metadataEntry.version || 1,
                 metadataEntry.compositeHash,
-                Address.createFromEncoded(metadataEntry.sourceAddress),
-                Address.createFromEncoded(metadataEntry.targetAddress),
+                DtoMapping.toAddress(metadataEntry.sourceAddress),
+                DtoMapping.toAddress(metadataEntry.targetAddress),
                 UInt64.fromHex(metadataEntry.scopedMetadataKey),
                 metadataEntry.metadataType.valueOf(),
                 Convert.decodeHex(metadataEntry.value),

--- a/src/infrastructure/MosaicHttp.ts
+++ b/src/infrastructure/MosaicHttp.ts
@@ -18,7 +18,6 @@ import { Observable } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 import { MosaicInfoDTO, MosaicRoutesApi } from 'symbol-openapi-typescript-fetch-client';
 import { DtoMapping } from '../core/utils/DtoMapping';
-import { Address } from '../model/account/Address';
 import { MerkleStateInfo } from '../model/blockchain';
 import { MosaicFlags } from '../model/mosaic/MosaicFlags';
 import { MosaicId } from '../model/mosaic/MosaicId';
@@ -133,7 +132,7 @@ export class MosaicHttp extends Http implements MosaicRepository {
             new MosaicId(mosaicInfo.mosaic.id),
             UInt64.fromNumericString(mosaicInfo.mosaic.supply),
             UInt64.fromNumericString(mosaicInfo.mosaic.startHeight),
-            Address.createFromEncoded(mosaicInfo.mosaic.ownerAddress),
+            DtoMapping.toAddress(mosaicInfo.mosaic.ownerAddress),
             mosaicInfo.mosaic.revision,
             new MosaicFlags(mosaicInfo.mosaic.flags),
             mosaicInfo.mosaic.divisibility,

--- a/src/infrastructure/MultisigHttp.ts
+++ b/src/infrastructure/MultisigHttp.ts
@@ -92,11 +92,11 @@ export class MultisigHttp extends Http implements MultisigRepository {
     private toMultisigAccountInfo(dto: MultisigAccountInfoDTO): MultisigAccountInfo {
         return new MultisigAccountInfo(
             dto.multisig.version || 1,
-            Address.createFromEncoded(dto.multisig.accountAddress),
+            DtoMapping.toAddress(dto.multisig.accountAddress),
             dto.multisig.minApproval,
             dto.multisig.minRemoval,
-            dto.multisig.cosignatoryAddresses.map((cosigner) => Address.createFromEncoded(cosigner)),
-            dto.multisig.multisigAddresses.map((multisig) => Address.createFromEncoded(multisig)),
+            dto.multisig.cosignatoryAddresses.map((cosigner) => DtoMapping.toAddress(cosigner)),
+            dto.multisig.multisigAddresses.map((multisig) => DtoMapping.toAddress(multisig)),
         );
     }
 }

--- a/src/infrastructure/NamespaceHttp.ts
+++ b/src/infrastructure/NamespaceHttp.ts
@@ -82,7 +82,7 @@ export class NamespaceHttp extends Http implements NamespaceRepository {
             body.accountNames.map(
                 (accountName) =>
                     new AccountNames(
-                        Address.createFromEncoded(accountName.address),
+                        DtoMapping.toAddress(accountName.address),
                         accountName.names.map((name) => {
                             return new NamespaceName(new NamespaceId(name), name);
                         }),
@@ -255,7 +255,7 @@ export class NamespaceHttp extends Http implements NamespaceRepository {
             dto.namespace.depth,
             NamespaceHttp.extractLevels(dto.namespace),
             NamespaceId.createFromEncoded(dto.namespace.parentId),
-            Address.createFromEncoded(dto.namespace.ownerAddress),
+            DtoMapping.toAddress(dto.namespace.ownerAddress),
             UInt64.fromNumericString(dto.namespace.startHeight),
             UInt64.fromNumericString(dto.namespace.endHeight),
             NamespaceHttp.extractAlias(dto.namespace),
@@ -292,7 +292,7 @@ export class NamespaceHttp extends Http implements NamespaceRepository {
         if (namespace.alias && namespace.alias.type.valueOf() === AliasType.Mosaic) {
             return new MosaicAlias(new MosaicId(namespace.alias.mosaicId!));
         } else if (namespace.alias && namespace.alias.type.valueOf() === AliasType.Address) {
-            return new AddressAlias(Address.createFromEncoded(namespace.alias.address!));
+            return new AddressAlias(DtoMapping.toAddress(namespace.alias.address!));
         }
         return new EmptyAlias();
     }

--- a/src/infrastructure/RestrictionMosaicHttp.ts
+++ b/src/infrastructure/RestrictionMosaicHttp.ts
@@ -24,7 +24,6 @@ import {
 } from 'symbol-openapi-typescript-fetch-client';
 import { DtoMapping } from '../core/utils';
 import { MerkleStateInfo, UInt64 } from '../model';
-import { Address } from '../model/account';
 import { MosaicId } from '../model/mosaic';
 import {
     MosaicAddressRestriction,
@@ -100,7 +99,7 @@ export class RestrictionMosaicHttp extends Http implements RestrictionMosaicRepo
                 dto.mosaicRestrictionEntry.compositeHash,
                 dto.mosaicRestrictionEntry.entryType.valueOf(),
                 new MosaicId(dto.mosaicRestrictionEntry.mosaicId),
-                Address.createFromEncoded(addressRestrictionDto.mosaicRestrictionEntry.targetAddress),
+                DtoMapping.toAddress(addressRestrictionDto.mosaicRestrictionEntry.targetAddress),
                 addressRestrictionDto.mosaicRestrictionEntry.restrictions.map(RestrictionMosaicHttp.toMosaicAddressRestrictionItem),
             );
         }

--- a/src/infrastructure/SecretLockHttp.ts
+++ b/src/infrastructure/SecretLockHttp.ts
@@ -18,7 +18,6 @@ import { Observable } from 'rxjs';
 import { SecretLockInfoDTO, SecretLockRoutesApi } from 'symbol-openapi-typescript-fetch-client';
 import { DtoMapping } from '../core/utils';
 import { UInt64 } from '../model';
-import { Address } from '../model/account';
 import { MerkleStateInfo } from '../model/blockchain';
 import { SecretLockInfo } from '../model/lock';
 import { MosaicId } from '../model/mosaic';
@@ -92,14 +91,14 @@ export class SecretLockHttp extends Http implements SecretLockRepository {
         return new SecretLockInfo(
             dto.lock.version || 1,
             dto.id,
-            Address.createFromEncoded(dto.lock.ownerAddress),
+            DtoMapping.toAddress(dto.lock.ownerAddress),
             new MosaicId(dto.lock.mosaicId),
             UInt64.fromNumericString(dto.lock.amount),
             UInt64.fromNumericString(dto.lock.endHeight),
             dto.lock.status.valueOf(),
             dto.lock.hashAlgorithm.valueOf(),
             dto.lock.secret,
-            Address.createFromEncoded(dto.lock.recipientAddress),
+            DtoMapping.toAddress(dto.lock.recipientAddress),
             dto.lock.compositeHash,
         );
     }

--- a/src/infrastructure/receipt/CreateReceiptFromDTO.ts
+++ b/src/infrastructure/receipt/CreateReceiptFromDTO.ts
@@ -15,6 +15,7 @@
  */
 
 import { ResolutionStatementInfoDTO, TransactionStatementInfoDTO } from 'symbol-openapi-typescript-fetch-client';
+import { DtoMapping } from '../../core/utils';
 import { UnresolvedMapping } from '../../core/utils/UnresolvedMapping';
 import { Address } from '../../model/account/Address';
 import { UnresolvedAddress } from '../../model/account/UnresolvedAddress';
@@ -85,7 +86,7 @@ export const createAddressResolutionStatement = (statementInfoDTO: ResolutionSta
         extractUnresolvedAddress(statementDTO.unresolved),
         statementDTO.resolutionEntries.map((entry) => {
             return new ResolutionEntry(
-                Address.createFromEncoded(entry.resolved),
+                DtoMapping.toAddress(entry.resolved),
                 new ReceiptSource(entry.source.primaryId, entry.source.secondaryId),
             );
         }),
@@ -100,7 +101,7 @@ export const createAddressResolutionStatement = (statementInfoDTO: ResolutionSta
  */
 const createBalanceChangeReceipt = (receiptDTO): Receipt => {
     return new BalanceChangeReceipt(
-        Address.createFromEncoded(receiptDTO.targetAddress),
+        DtoMapping.toAddress(receiptDTO.targetAddress),
         new MosaicId(receiptDTO.mosaicId),
         UInt64.fromNumericString(receiptDTO.amount),
         receiptDTO.version,
@@ -116,8 +117,8 @@ const createBalanceChangeReceipt = (receiptDTO): Receipt => {
  */
 const createBalanceTransferReceipt = (receiptDTO): Receipt => {
     return new BalanceTransferReceipt(
-        Address.createFromEncoded(receiptDTO.senderAddress),
-        Address.createFromEncoded(receiptDTO.recipientAddress),
+        DtoMapping.toAddress(receiptDTO.senderAddress),
+        DtoMapping.toAddress(receiptDTO.recipientAddress),
         new MosaicId(receiptDTO.mosaicId),
         UInt64.fromNumericString(receiptDTO.amount),
         receiptDTO.version,

--- a/src/model/transaction/AddressAliasTransaction.ts
+++ b/src/model/transaction/AddressAliasTransaction.ts
@@ -23,6 +23,7 @@ import {
     TransactionBuilder,
 } from 'catbuffer-typescript';
 import { Convert } from '../../core/format';
+import { DtoMapping } from '../../core/utils';
 import { Address } from '../account/Address';
 import { PublicAccount } from '../account/PublicAccount';
 import { AliasAction } from '../namespace/AliasAction';
@@ -131,7 +132,7 @@ export class AddressAliasTransaction extends Transaction {
                 : Deadline.createFromDTO((builder as AddressAliasTransactionBuilder).getDeadline().timestamp),
             builder.getAliasAction().valueOf(),
             new NamespaceId(builder.getNamespaceId().namespaceId),
-            Address.createFromEncoded(Convert.uint8ToHex(builder.getAddress().address)),
+            DtoMapping.toAddress(Convert.uint8ToHex(builder.getAddress().address)),
             networkType,
             isEmbedded ? new UInt64([0, 0]) : new UInt64((builder as AddressAliasTransactionBuilder).fee.amount),
             signature,

--- a/test/core/utils/DtoMapping.spec.ts
+++ b/test/core/utils/DtoMapping.spec.ts
@@ -23,6 +23,7 @@ import {
     MerkleTreeLeafDTO,
 } from 'symbol-openapi-typescript-fetch-client';
 import { DtoMapping } from '../../../src/core/utils/DtoMapping';
+import { Address } from '../../../src/model/account';
 import { PublicAccount } from '../../../src/model/account/PublicAccount';
 import { MosaicId } from '../../../src/model/mosaic/MosaicId';
 import { NetworkType } from '../../../src/model/network/NetworkType';
@@ -110,6 +111,35 @@ describe('DtoMapping', () => {
         expect(DtoMapping.toSimpleHex("0x017D'1694'0477'B3F5")).to.be.equal('017D16940477B3F5');
         expect(DtoMapping.toSimpleHex('017D16940477B3F5')).to.be.equal('017D16940477B3F5');
         expect(DtoMapping.toSimpleHex("0x29C6'42F2'F432'8612")).to.be.equal('29C642F2F4328612');
+    });
+
+    it('toAddress', () => {
+        expect(DtoMapping.toAddress('7826D27E1D0A26CA4E316F901E23E55C8711DB20DF5C49B5').plain()).to.be.equal(
+            'PATNE7Q5BITMUTRRN6IB4I7FLSDRDWZA35OETNI',
+        );
+
+        expect(DtoMapping.toAddress('7826D27E1D0A26CA4E316F901E23E55C8711DB20DF5C49B5').encoded()).to.be.equal(
+            '7826D27E1D0A26CA4E316F901E23E55C8711DB20DF5C49B5',
+        );
+        expect(DtoMapping.toAddress('TDR6EW2WBHJQDYMNGFX2UBZHMMZC5PGL2YBO3KA').plain()).to.be.equal(
+            'TDR6EW2WBHJQDYMNGFX2UBZHMMZC5PGL2YBO3KA',
+        );
+
+        expect(DtoMapping.toAddress('TDR6-EW2-WBHJQDYMNGFX-2UBZHMMZC5PG-L2YBO3KA').plain()).to.be.equal(
+            'TDR6EW2WBHJQDYMNGFX2UBZHMMZC5PGL2YBO3KA',
+        );
+        // This method should raise! It does not validate the chechsum!
+        expect(Address.createFromEncoded('917E7E29A01014C2F3000000000000000000000000000000').plain()).to.be.equal(
+            'SF7H4KNACAKMF4YAAAAAAAAAAAAAAAAAAAAAAAA',
+        );
+        // This method should raise! It does not validate the chechsum!
+        expect(Address.createFromRawAddress('SF7H4KNACAKMF4YAAAAAAAAAAAAAAAAAAAAAAAA').plain()).to.be.equal(
+            'SF7H4KNACAKMF4YAAAAAAAAAAAAAAAAAAAAAAAA',
+        );
+        expect(Address.isValidEncodedAddress('917E7E29A01014C2F3000000000000000000000000000000')).to.be.equal(false);
+        expect(() => DtoMapping.toAddress('917E7E29A01014C2F3000000000000000000000000000000')).to.throw;
+        expect(() => DtoMapping.toAddress('XDR6-EW2-WBHJQDYMNGFX-2UBZHMMZC5PG-L2YBO3KA')).to.throw;
+        expect(() => DtoMapping.toAddress('917E7E29A01014C2F3000000000000000000000000000')).to.throw;
     });
 
     it('parse merkle tree', () => {

--- a/test/core/utils/UnresolvedMapping.spec.ts
+++ b/test/core/utils/UnresolvedMapping.spec.ts
@@ -59,16 +59,34 @@ describe('UnresolvedMapping', () => {
             expect(unresolved instanceof NamespaceId).to.be.false;
         });
 
+        it('can map alias address', () => {
+            const unresolved = UnresolvedMapping.toUnresolvedAddress('THBIMC3THGH5RUYAAAAAAAAAAAAAAAAAAAAAAAA');
+            expect(unresolved instanceof Address).to.be.false;
+            expect(unresolved instanceof NamespaceId).to.be.true;
+            expect(Convert.uint8ToHex(unresolved.encodeUnresolvedAddress(NetworkType.TEST_NET))).eq(
+                '99C2860B73398FD8D3000000000000000000000000000000',
+            );
+        });
+
+        it('can map real address', () => {
+            const unresolved = UnresolvedMapping.toUnresolvedAddress('NATNE7Q5BITMUTRRN6IB4I7FLSDRDWZA35C4KNQ');
+            expect(unresolved instanceof Address).to.be.true;
+            expect(unresolved instanceof NamespaceId).to.be.false;
+            expect(Convert.uint8ToHex(unresolved.encodeUnresolvedAddress(NetworkType.MAIN_NET))).eq(
+                '6826D27E1D0A26CA4E316F901E23E55C8711DB20DF45C536',
+            );
+        });
+
         it('can map hex string to NamespaceId', () => {
             const unresolved = UnresolvedMapping.toUnresolvedMosaic(namespacId.toHex());
-            expect(unresolved instanceof Address).to.be.false;
+            expect(unresolved instanceof MosaicId).to.be.false;
             expect(unresolved instanceof NamespaceId).to.be.true;
         });
 
         it('should throw error if id not in hex', () => {
             expect(() => {
                 UnresolvedMapping.toUnresolvedAddress('test');
-            }).to.throw(Error, 'Input string is not in valid hexadecimal notation.');
+            }).to.throw(Error, 'Address TEST has to be 39 characters long');
         });
     });
 

--- a/test/infrastructure/receipt/CreateReceiptFromDTO.spec.ts
+++ b/test/infrastructure/receipt/CreateReceiptFromDTO.spec.ts
@@ -163,7 +163,7 @@ describe('Receipt - CreateStatementFromDTO', () => {
                                     primaryId: 4,
                                     secondaryId: 0,
                                 },
-                                resolved: '917E7E29A01014C2F3000000000000000000000000000000',
+                                resolved: '7826D27E1D0A26CA4E316F901E23E55C8711DB20DF5C49B5',
                             },
                         ],
                     },
@@ -179,7 +179,7 @@ describe('Receipt - CreateStatementFromDTO', () => {
                                     primaryId: 2,
                                     secondaryId: 0,
                                 },
-                                resolved: '9103B60AAF27626883000000000000000000000000000000',
+                                resolved: 'PATNE7Q5BITMUTRRN6IB4I7FLSDRDWZA35OETNI',
                             },
                         ],
                     },
@@ -275,7 +275,7 @@ describe('Receipt - CreateStatementFromDTO', () => {
         deepEqual(unresolvedAddress.toHex(), '83686227AF0AB603');
         expect(statement.addressResolutionStatements[0].resolutionEntries.length).to.be.equal(1);
         expect((statement.addressResolutionStatements[0].resolutionEntries[0].resolved as Address).plain()).to.be.equal(
-            Address.createFromEncoded('917E7E29A01014C2F3000000000000000000000000000000').plain(),
+            'PATNE7Q5BITMUTRRN6IB4I7FLSDRDWZA35OETNI',
         );
 
         deepEqual(statement.mosaicResolutionStatements[0].height, UInt64.fromNumericString('1506'));
@@ -299,7 +299,7 @@ describe('Receipt - CreateStatementFromDTO', () => {
                                     primaryId: 4,
                                     secondaryId: 0,
                                 },
-                                resolved: '917E7E29A01014C2F3000000000000000000000000000000',
+                                resolved: account.address.encoded(),
                             },
                         ],
                     },
@@ -321,7 +321,7 @@ describe('Receipt - CreateStatementFromDTO', () => {
                             primaryId: 4,
                             secondaryId: 0,
                         },
-                        resolved: '917E7E29A01014C2F3000000000000000000000000000000',
+                        resolved: account.address.encoded(),
                     },
                 ],
             },

--- a/test/model/receipt/Receipt.spec.ts
+++ b/test/model/receipt/Receipt.spec.ts
@@ -84,7 +84,7 @@ describe('Receipt', () => {
                                 primaryId: 4,
                                 secondaryId: 0,
                             },
-                            resolved: '917E7E29A01014C2F3000000000000000000000000000000',
+                            resolved: '7826D27E1D0A26CA4E316F901E23E55C8711DB20DF5C49B5',
                         },
                     ],
                 },
@@ -319,10 +319,7 @@ describe('Receipt', () => {
             (statement.unresolved as Address).plain(),
             Address.createFromEncoded('9103B60AAF27626883000000000000000000000000000000').plain(),
         );
-        deepEqual(
-            (statement.resolutionEntries[0].resolved as Address).plain(),
-            Address.createFromEncoded('917E7E29A01014C2F3000000000000000000000000000000').plain(),
-        );
+        deepEqual((statement.resolutionEntries[0].resolved as Address).plain(), 'PATNE7Q5BITMUTRRN6IB4I7FLSDRDWZA35OETNI');
     });
 
     it('should createComplete a inflation receipt', () => {
@@ -355,7 +352,7 @@ describe('Receipt', () => {
     it('should generate hash for AddressResolutionStatement', () => {
         const receipt = createAddressResolutionStatement(statementDTO.addressResolutionStatements[0]);
         const hash = receipt.generateHash(NetworkType.MAIN_NET);
-        expect(hash).to.be.equal('AA9B667C37C8A19902F3E1098FCEE681318455551CC2FBE9B81E8FA47007CA79');
+        expect(hash).to.be.equal('EBCD71F16C70F7E34E8B9A98A174B759DB8457093CCF3ECAA3D05721E36AAA33');
     });
 
     it('should generate hash for TransactionStatement', () => {


### PR DESCRIPTION
This is the SDK side of https://github.com/symbol/catapult-rest/pull/611

The new rest mappers will accept both encoded/hex and plain/decoded addresses. It will buffer the migration allowing the SDK rest client to be compatible with old and new rests. Eventually, we should only allow base32 addresses. Apps only need to upgrade the SDK, no code change is required.

A migration plan could be:
- Merge and release this SDK fix.
- Merge and release the Rest fix.
- Upgrade SDKs in all our apps (CLIs, explorers, wallets, etc). Release the apps. The apps will be old and new rest compatible. 
- Migrate testnet, mainnet, and community nodes to the new rest when possible.  

No flag is required. 

Related issues:
https://github.com/symbol/symbol-sdk-typescript-javascript/issues/801
https://github.com/symbol/symbol-sdk-typescript-javascript/issues/802