### PR TITLE
fix: Upgraded catbuffer to the latest schemas names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@js-joda/core": "^3.2.0",
-                "catbuffer-typescript": "1.0.0",
+                "catbuffer-typescript": "^1.0.1-alpha-202111091444",
                 "crypto-js": "^4.0.0",
                 "futoin-hkdf": "^1.3.2",
                 "js-sha256": "^0.9.0",
@@ -1380,9 +1380,9 @@
             "dev": true
         },
         "node_modules/catbuffer-typescript": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/catbuffer-typescript/-/catbuffer-typescript-1.0.0.tgz",
-            "integrity": "sha512-pVpsk0AGcPjaQQVax2rz4EbIQ3/9LvNOYuY2b3KKYlp9Smd6Aohx6gPhZV//D7IYWsFcqntyVbf8/Z4xc5PT+w=="
+            "version": "1.0.1-alpha-202111091444",
+            "resolved": "https://registry.npmjs.org/catbuffer-typescript/-/catbuffer-typescript-1.0.1-alpha-202111091444.tgz",
+            "integrity": "sha512-moGTO5sX8a4sP57RuhTUzktbjmX5weZp6F50cWMPFzR4In1SqaNWgPTR98HnHTDEeXAb/o/mog1UMZj5MvHOzQ=="
         },
         "node_modules/chai": {
             "version": "4.2.0",
@@ -7661,9 +7661,9 @@
             "dev": true
         },
         "catbuffer-typescript": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/catbuffer-typescript/-/catbuffer-typescript-1.0.0.tgz",
-            "integrity": "sha512-pVpsk0AGcPjaQQVax2rz4EbIQ3/9LvNOYuY2b3KKYlp9Smd6Aohx6gPhZV//D7IYWsFcqntyVbf8/Z4xc5PT+w=="
+            "version": "1.0.1-alpha-202111091444",
+            "resolved": "https://registry.npmjs.org/catbuffer-typescript/-/catbuffer-typescript-1.0.1-alpha-202111091444.tgz",
+            "integrity": "sha512-moGTO5sX8a4sP57RuhTUzktbjmX5weZp6F50cWMPFzR4In1SqaNWgPTR98HnHTDEeXAb/o/mog1UMZj5MvHOzQ=="
         },
         "chai": {
             "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     },
     "dependencies": {
         "@js-joda/core": "^3.2.0",
-        "catbuffer-typescript": "1.0.0",
+        "catbuffer-typescript": "^1.0.1-alpha-202111091444",
         "crypto-js": "^4.0.0",
         "futoin-hkdf": "^1.3.2",
         "js-sha256": "^0.9.0",

--- a/src/model/account/AccountInfo.ts
+++ b/src/model/account/AccountInfo.ts
@@ -27,10 +27,10 @@ import {
     ImportanceDto,
     ImportanceHeightDto,
     ImportanceSnapshotBuilder,
-    KeyDto,
     MosaicBuilder,
     PinnedVotingKeyBuilder,
-    VotingKeyDto,
+    PublicKeyDto,
+    VotingPublicKeyDto,
 } from 'catbuffer-typescript';
 import { Convert } from '../../core/format';
 import { Mosaic, MosaicId } from '../mosaic';
@@ -112,16 +112,16 @@ export class AccountInfo {
     public serialize(): Uint8Array {
         const address: AddressDto = this.address.toBuilder();
         const addressHeight: HeightDto = new HeightDto(this.addressHeight.toDTO());
-        const publicKey: KeyDto = new KeyDto(Convert.hexToUint8(this.publicKey));
+        const publicKey: PublicKeyDto = new PublicKeyDto(Convert.hexToUint8(this.publicKey));
         const publicKeyHeight: HeightDto = new HeightDto(this.publicKeyHeight.toDTO());
         const accountType = this.accountType.valueOf();
         const supplementalPublicKeysMask = this.getAccountKeyTypeFlags();
         const votingPublicKeys: PinnedVotingKeyBuilder[] =
             this.supplementalPublicKeys.voting?.map((key) => AccountInfo.toPinnedVotingKeyBuilder(key)) || [];
         const balances: MosaicBuilder[] = this.mosaics.map((m) => AccountInfo.toMosaicBuilder(m));
-        const linkedPublicKey: KeyDto | undefined = AccountInfo.toKeyDto(this?.supplementalPublicKeys?.linked?.publicKey);
-        const nodePublicKey = AccountInfo.toKeyDto(this?.supplementalPublicKeys?.node?.publicKey);
-        const vrfPublicKey = AccountInfo.toKeyDto(this?.supplementalPublicKeys?.vrf?.publicKey);
+        const linkedPublicKey: PublicKeyDto | undefined = AccountInfo.toPublicKeyDto(this?.supplementalPublicKeys?.linked?.publicKey);
+        const nodePublicKey = AccountInfo.toPublicKeyDto(this?.supplementalPublicKeys?.node?.publicKey);
+        const vrfPublicKey = AccountInfo.toPublicKeyDto(this?.supplementalPublicKeys?.vrf?.publicKey);
         const importanceSnapshots: ImportanceSnapshotBuilder = new ImportanceSnapshotBuilder(
             new ImportanceDto(this.importance.toDTO()),
             new ImportanceHeightDto(this.importanceHeight.toDTO()),
@@ -179,21 +179,21 @@ export class AccountInfo {
     }
 
     private static toPinnedVotingKeyBuilder(key: AccountLinkVotingKey): PinnedVotingKeyBuilder {
-        const votingKeyDto = new VotingKeyDto(Convert.hexToUint8(key.publicKey).slice(0, 32));
+        const votingPublicKeyDto = new VotingPublicKeyDto(Convert.hexToUint8(key.publicKey).slice(0, 32));
         const startEpoch: FinalizationEpochDto = new FinalizationEpochDto(key.startEpoch);
         const endEpoch: FinalizationEpochDto = new FinalizationEpochDto(key.endEpoch);
-        return new PinnedVotingKeyBuilder(votingKeyDto, startEpoch, endEpoch);
+        return new PinnedVotingKeyBuilder(votingPublicKeyDto, startEpoch, endEpoch);
     }
 
     private static toMosaicBuilder(m: Mosaic): MosaicBuilder {
         return new MosaicBuilder((m.id as MosaicId).toBuilder(), new AmountDto(m.amount.toDTO()));
     }
 
-    private static toKeyDto(publicKey: string | undefined): KeyDto | undefined {
+    private static toPublicKeyDto(publicKey: string | undefined): PublicKeyDto | undefined {
         if (!publicKey) {
             return undefined;
         }
-        return new KeyDto(Convert.hexToUint8(publicKey));
+        return new PublicKeyDto(Convert.hexToUint8(publicKey));
     }
 
     private static toHeightActivityBucketsBuilder(b: ActivityBucket): HeightActivityBucketBuilder {

--- a/src/model/account/PublicAccount.ts
+++ b/src/model/account/PublicAccount.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { KeyDto } from 'catbuffer-typescript';
+import { PublicKeyDto } from 'catbuffer-typescript';
 import { KeyPair } from '../../core/crypto';
 import { Convert } from '../../core/format';
 import { NetworkType } from '../network/NetworkType';
@@ -101,7 +101,7 @@ export class PublicAccount {
     /**
      * Create Builder object
      */
-    toBuilder(): KeyDto {
-        return new KeyDto(Convert.hexToUint8(this.publicKey));
+    toBuilder(): PublicKeyDto {
+        return new PublicKeyDto(Convert.hexToUint8(this.publicKey));
     }
 }

--- a/src/model/transaction/AccountAddressRestrictionTransaction.ts
+++ b/src/model/transaction/AccountAddressRestrictionTransaction.ts
@@ -112,7 +112,7 @@ export class AccountAddressRestrictionTransaction extends Transaction {
         const builder = isEmbedded
             ? EmbeddedAccountAddressRestrictionTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : AccountAddressRestrictionTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction = AccountAddressRestrictionTransaction.create(

--- a/src/model/transaction/AccountKeyLinkTransaction.ts
+++ b/src/model/transaction/AccountKeyLinkTransaction.ts
@@ -19,7 +19,7 @@ import {
     AmountDto,
     EmbeddedAccountKeyLinkTransactionBuilder,
     EmbeddedTransactionBuilder,
-    KeyDto,
+    PublicKeyDto,
     TimestampDto,
     TransactionBuilder,
 } from 'catbuffer-typescript';
@@ -114,14 +114,14 @@ export class AccountKeyLinkTransaction extends Transaction {
         const builder = isEmbedded
             ? EmbeddedAccountKeyLinkTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : AccountKeyLinkTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction = AccountKeyLinkTransaction.create(
             isEmbedded
                 ? Deadline.createEmtpy()
                 : Deadline.createFromDTO((builder as AccountKeyLinkTransactionBuilder).getDeadline().timestamp),
-            Convert.uint8ToHex(builder.getLinkedPublicKey().key),
+            Convert.uint8ToHex(builder.getLinkedPublicKey().publicKey),
             builder.getLinkAction().valueOf(),
             networkType,
             isEmbedded ? new UInt64([0, 0]) : new UInt64((builder as AccountKeyLinkTransactionBuilder).fee.amount),
@@ -144,7 +144,7 @@ export class AccountKeyLinkTransaction extends Transaction {
             TransactionType.ACCOUNT_KEY_LINK.valueOf(),
             new AmountDto(this.maxFee.toDTO()),
             new TimestampDto(this.deadline.toDTO()),
-            new KeyDto(Convert.hexToUint8(this.linkedPublicKey)),
+            new PublicKeyDto(Convert.hexToUint8(this.linkedPublicKey)),
             this.linkAction.valueOf(),
         );
     }
@@ -159,7 +159,7 @@ export class AccountKeyLinkTransaction extends Transaction {
             this.versionToDTO(),
             this.networkType.valueOf(),
             TransactionType.ACCOUNT_KEY_LINK.valueOf(),
-            new KeyDto(Convert.hexToUint8(this.linkedPublicKey)),
+            new PublicKeyDto(Convert.hexToUint8(this.linkedPublicKey)),
             this.linkAction.valueOf(),
         );
     }

--- a/src/model/transaction/AccountMetadataTransaction.ts
+++ b/src/model/transaction/AccountMetadataTransaction.ts
@@ -132,7 +132,7 @@ export class AccountMetadataTransaction extends Transaction {
         const builder = isEmbedded
             ? EmbeddedAccountMetadataTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : AccountMetadataTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction = AccountMetadataTransaction.create(

--- a/src/model/transaction/AccountMosaicRestrictionTransaction.ts
+++ b/src/model/transaction/AccountMosaicRestrictionTransaction.ts
@@ -115,7 +115,7 @@ export class AccountMosaicRestrictionTransaction extends Transaction {
         const builder = isEmbedded
             ? EmbeddedAccountMosaicRestrictionTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : AccountMosaicRestrictionTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction = AccountMosaicRestrictionTransaction.create(

--- a/src/model/transaction/AccountOperationRestrictionTransaction.ts
+++ b/src/model/transaction/AccountOperationRestrictionTransaction.ts
@@ -110,7 +110,7 @@ export class AccountOperationRestrictionTransaction extends Transaction {
         const builder = isEmbedded
             ? EmbeddedAccountOperationRestrictionTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : AccountOperationRestrictionTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
-        const signer = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signer = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction = AccountOperationRestrictionTransaction.create(

--- a/src/model/transaction/AddressAliasTransaction.ts
+++ b/src/model/transaction/AddressAliasTransaction.ts
@@ -123,7 +123,7 @@ export class AddressAliasTransaction extends Transaction {
         const builder = isEmbedded
             ? EmbeddedAddressAliasTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : AddressAliasTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction = AddressAliasTransaction.create(

--- a/src/model/transaction/AggregateTransaction.ts
+++ b/src/model/transaction/AggregateTransaction.ts
@@ -22,7 +22,7 @@ import {
     EmbeddedTransactionBuilder,
     GeneratorUtils,
     Hash256Dto,
-    KeyDto,
+    PublicKeyDto,
     SignatureDto,
     TimestampDto,
     TransactionBuilder,
@@ -162,12 +162,12 @@ export class AggregateTransaction extends Transaction {
         const type = (builder.type as number) as TransactionType;
         const innerTransactions = builder.getTransactions();
         const networkType = builder.getNetwork().valueOf();
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const signature = Transaction.getSignatureFromPayload(payload, false);
         const consignatures = builder.getCosignatures().map((cosig) => {
             return new AggregateTransactionCosignature(
                 Convert.uint8ToHex(cosig.signature.signature),
-                PublicAccount.createFromPublicKey(Convert.uint8ToHex(cosig.signerPublicKey.key), networkType),
+                PublicAccount.createFromPublicKey(Convert.uint8ToHex(cosig.signerPublicKey.publicKey), networkType),
                 new UInt64(cosig.version),
             );
         });
@@ -302,7 +302,7 @@ export class AggregateTransaction extends Transaction {
         const cosignatures = this.cosignatures.map((cosignature) => {
             const signerBytes = Convert.hexToUint8(cosignature.signer.publicKey);
             const signatureBytes = Convert.hexToUint8(cosignature.signature);
-            return new CosignatureBuilder(cosignature.version.toDTO(), new KeyDto(signerBytes), new SignatureDto(signatureBytes));
+            return new CosignatureBuilder(cosignature.version.toDTO(), new PublicKeyDto(signerBytes), new SignatureDto(signatureBytes));
         });
 
         const builder =

--- a/src/model/transaction/LockFundsTransaction.ts
+++ b/src/model/transaction/LockFundsTransaction.ts
@@ -129,7 +129,7 @@ export class LockFundsTransaction extends Transaction {
         const builder = isEmbedded
             ? EmbeddedHashLockTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : HashLockTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction = LockFundsTransaction.create(

--- a/src/model/transaction/MosaicAddressRestrictionTransaction.ts
+++ b/src/model/transaction/MosaicAddressRestrictionTransaction.ts
@@ -150,7 +150,7 @@ export class MosaicAddressRestrictionTransaction extends Transaction {
         const builder = isEmbedded
             ? EmbeddedMosaicAddressRestrictionTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : MosaicAddressRestrictionTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction = MosaicAddressRestrictionTransaction.create(

--- a/src/model/transaction/MosaicAliasTransaction.ts
+++ b/src/model/transaction/MosaicAliasTransaction.ts
@@ -119,7 +119,7 @@ export class MosaicAliasTransaction extends Transaction {
         const builder = isEmbedded
             ? EmbeddedMosaicAliasTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : MosaicAliasTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction = MosaicAliasTransaction.create(

--- a/src/model/transaction/MosaicDefinitionTransaction.ts
+++ b/src/model/transaction/MosaicDefinitionTransaction.ts
@@ -143,7 +143,7 @@ export class MosaicDefinitionTransaction extends Transaction {
         const builder = isEmbedded
             ? EmbeddedMosaicDefinitionTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : MosaicDefinitionTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction = MosaicDefinitionTransaction.create(

--- a/src/model/transaction/MosaicGlobalRestrictionTransaction.ts
+++ b/src/model/transaction/MosaicGlobalRestrictionTransaction.ts
@@ -166,7 +166,7 @@ export class MosaicGlobalRestrictionTransaction extends Transaction {
         const builder = isEmbedded
             ? EmbeddedMosaicGlobalRestrictionTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : MosaicGlobalRestrictionTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction = MosaicGlobalRestrictionTransaction.create(

--- a/src/model/transaction/MosaicMetadataTransaction.ts
+++ b/src/model/transaction/MosaicMetadataTransaction.ts
@@ -144,7 +144,7 @@ export class MosaicMetadataTransaction extends Transaction {
         const builder = isEmbedded
             ? EmbeddedMosaicMetadataTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : MosaicMetadataTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction = MosaicMetadataTransaction.create(

--- a/src/model/transaction/MosaicSupplyChangeTransaction.ts
+++ b/src/model/transaction/MosaicSupplyChangeTransaction.ts
@@ -126,7 +126,7 @@ export class MosaicSupplyChangeTransaction extends Transaction {
         const builder = isEmbedded
             ? EmbeddedMosaicSupplyChangeTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : MosaicSupplyChangeTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction = MosaicSupplyChangeTransaction.create(

--- a/src/model/transaction/MultisigAccountModificationTransaction.ts
+++ b/src/model/transaction/MultisigAccountModificationTransaction.ts
@@ -134,7 +134,7 @@ export class MultisigAccountModificationTransaction extends Transaction {
         const builder = isEmbedded
             ? EmbeddedMultisigAccountModificationTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : MultisigAccountModificationTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction = MultisigAccountModificationTransaction.create(

--- a/src/model/transaction/NamespaceMetadataTransaction.ts
+++ b/src/model/transaction/NamespaceMetadataTransaction.ts
@@ -141,7 +141,7 @@ export class NamespaceMetadataTransaction extends Transaction {
         const builder = isEmbedded
             ? EmbeddedNamespaceMetadataTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : NamespaceMetadataTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction = NamespaceMetadataTransaction.create(

--- a/src/model/transaction/NamespaceRegistrationTransaction.ts
+++ b/src/model/transaction/NamespaceRegistrationTransaction.ts
@@ -180,7 +180,7 @@ export class NamespaceRegistrationTransaction extends Transaction {
             ? EmbeddedNamespaceRegistrationTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : NamespaceRegistrationTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
         const registrationType = builder.getRegistrationType().valueOf();
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction =
@@ -217,7 +217,7 @@ export class NamespaceRegistrationTransaction extends Transaction {
     protected createBuilder(): TransactionBuilder {
         let transactionBuilder: NamespaceRegistrationTransactionBuilder;
         if (this.registrationType === NamespaceRegistrationType.RootNamespace) {
-            transactionBuilder = NamespaceRegistrationTransactionBuilder.createNamespaceRegistrationTransactionBuilderRoot(
+            transactionBuilder = NamespaceRegistrationTransactionBuilder.createNamespaceRegistrationTransactionBuilderROOT(
                 this.getSignatureAsBuilder(),
                 this.getSignerAsBuilder(),
                 this.versionToDTO(),
@@ -230,7 +230,7 @@ export class NamespaceRegistrationTransaction extends Transaction {
                 Convert.hexToUint8(Convert.utf8ToHex(this.namespaceName)),
             );
         } else {
-            transactionBuilder = NamespaceRegistrationTransactionBuilder.createNamespaceRegistrationTransactionBuilderChild(
+            transactionBuilder = NamespaceRegistrationTransactionBuilder.createNamespaceRegistrationTransactionBuilderCHILD(
                 this.getSignatureAsBuilder(),
                 this.getSignerAsBuilder(),
                 this.versionToDTO(),
@@ -252,7 +252,7 @@ export class NamespaceRegistrationTransaction extends Transaction {
      */
     public toEmbeddedTransaction(): EmbeddedTransactionBuilder {
         if (this.registrationType === NamespaceRegistrationType.RootNamespace) {
-            return EmbeddedNamespaceRegistrationTransactionBuilder.createEmbeddedNamespaceRegistrationTransactionBuilderRoot(
+            return EmbeddedNamespaceRegistrationTransactionBuilder.createEmbeddedNamespaceRegistrationTransactionBuilderROOT(
                 this.getSignerAsBuilder(),
                 this.versionToDTO(),
                 this.networkType.valueOf(),
@@ -262,7 +262,7 @@ export class NamespaceRegistrationTransaction extends Transaction {
                 Convert.hexToUint8(Convert.utf8ToHex(this.namespaceName)),
             );
         }
-        return EmbeddedNamespaceRegistrationTransactionBuilder.createEmbeddedNamespaceRegistrationTransactionBuilderChild(
+        return EmbeddedNamespaceRegistrationTransactionBuilder.createEmbeddedNamespaceRegistrationTransactionBuilderCHILD(
             this.getSignerAsBuilder(),
             this.versionToDTO(),
             this.networkType.valueOf(),

--- a/src/model/transaction/NodeKeyLinkTransaction.ts
+++ b/src/model/transaction/NodeKeyLinkTransaction.ts
@@ -18,8 +18,8 @@ import {
     AmountDto,
     EmbeddedNodeKeyLinkTransactionBuilder,
     EmbeddedTransactionBuilder,
-    KeyDto,
     NodeKeyLinkTransactionBuilder,
+    PublicKeyDto,
     TimestampDto,
     TransactionBuilder,
 } from 'catbuffer-typescript';
@@ -110,14 +110,14 @@ export class NodeKeyLinkTransaction extends Transaction {
         const builder = isEmbedded
             ? EmbeddedNodeKeyLinkTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : NodeKeyLinkTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction = NodeKeyLinkTransaction.create(
             isEmbedded
                 ? Deadline.createEmtpy()
                 : Deadline.createFromDTO((builder as NodeKeyLinkTransactionBuilder).getDeadline().timestamp),
-            Convert.uint8ToHex(builder.getLinkedPublicKey().key),
+            Convert.uint8ToHex(builder.getLinkedPublicKey().publicKey),
             builder.getLinkAction().valueOf(),
             networkType,
             isEmbedded ? new UInt64([0, 0]) : new UInt64((builder as NodeKeyLinkTransactionBuilder).fee.amount),
@@ -140,7 +140,7 @@ export class NodeKeyLinkTransaction extends Transaction {
             TransactionType.NODE_KEY_LINK.valueOf(),
             new AmountDto(this.maxFee.toDTO()),
             new TimestampDto(this.deadline.toDTO()),
-            new KeyDto(Convert.hexToUint8(this.linkedPublicKey)),
+            new PublicKeyDto(Convert.hexToUint8(this.linkedPublicKey)),
             this.linkAction.valueOf(),
         );
     }
@@ -155,7 +155,7 @@ export class NodeKeyLinkTransaction extends Transaction {
             this.versionToDTO(),
             this.networkType.valueOf(),
             TransactionType.NODE_KEY_LINK.valueOf(),
-            new KeyDto(Convert.hexToUint8(this.linkedPublicKey)),
+            new PublicKeyDto(Convert.hexToUint8(this.linkedPublicKey)),
             this.linkAction.valueOf(),
         );
     }

--- a/src/model/transaction/SecretLockTransaction.ts
+++ b/src/model/transaction/SecretLockTransaction.ts
@@ -145,7 +145,7 @@ export class SecretLockTransaction extends Transaction {
         const builder = isEmbedded
             ? EmbeddedSecretLockTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : SecretLockTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction = SecretLockTransaction.create(

--- a/src/model/transaction/SecretProofTransaction.ts
+++ b/src/model/transaction/SecretProofTransaction.ts
@@ -122,7 +122,7 @@ export class SecretProofTransaction extends Transaction {
         const builder = isEmbedded
             ? EmbeddedSecretProofTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : SecretProofTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction = SecretProofTransaction.create(

--- a/src/model/transaction/Transaction.ts
+++ b/src/model/transaction/Transaction.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { EmbeddedTransactionBuilder, KeyDto, SignatureDto, TransactionBuilder } from 'catbuffer-typescript';
+import { EmbeddedTransactionBuilder, PublicKeyDto, SignatureDto, TransactionBuilder } from 'catbuffer-typescript';
 import { KeyPair, SHA3Hasher } from '../../core/crypto';
 import { Convert } from '../../core/format';
 import { DtoMapping } from '../../core/utils';
@@ -481,10 +481,10 @@ export abstract class Transaction {
     /**
      * @internal
      *
-     * Converts the optional signer to a KeyDto that can be serialized.
+     * Converts the optional signer to a PublicKeyDto that can be serialized.
      */
-    protected getSignerAsBuilder(): KeyDto {
-        return this.signer?.toBuilder() || new KeyDto(new Uint8Array(32));
+    protected getSignerAsBuilder(): PublicKeyDto {
+        return this.signer?.toBuilder() || new PublicKeyDto(new Uint8Array(32));
     }
 
     /**

--- a/src/model/transaction/TransferTransaction.ts
+++ b/src/model/transaction/TransferTransaction.ts
@@ -132,7 +132,7 @@ export class TransferTransaction extends Transaction {
         const builder = isEmbedded
             ? EmbeddedTransferTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : TransferTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction = TransferTransaction.create(

--- a/src/model/transaction/VotingKeyLinkTransaction.ts
+++ b/src/model/transaction/VotingKeyLinkTransaction.ts
@@ -21,8 +21,8 @@ import {
     FinalizationEpochDto,
     TimestampDto,
     TransactionBuilder,
-    VotingKeyDto,
     VotingKeyLinkTransactionBuilder,
+    VotingPublicKeyDto,
 } from 'catbuffer-typescript';
 import { Convert } from '../../core/format';
 import { Address, PublicAccount } from '../account';
@@ -116,14 +116,14 @@ export class VotingKeyLinkTransaction extends Transaction {
         const builder = isEmbedded
             ? EmbeddedVotingKeyLinkTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : VotingKeyLinkTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction = VotingKeyLinkTransaction.create(
             isEmbedded
                 ? Deadline.createEmtpy()
                 : Deadline.createFromDTO((builder as VotingKeyLinkTransactionBuilder).getDeadline().timestamp),
-            Convert.uint8ToHex(builder.getLinkedPublicKey().votingKey),
+            Convert.uint8ToHex(builder.getLinkedPublicKey().votingPublicKey),
             builder.getStartEpoch().finalizationEpoch,
             builder.getEndEpoch().finalizationEpoch,
             builder.getLinkAction().valueOf(),
@@ -149,7 +149,7 @@ export class VotingKeyLinkTransaction extends Transaction {
             TransactionType.VOTING_KEY_LINK.valueOf(),
             new AmountDto(this.maxFee.toDTO()),
             new TimestampDto(this.deadline.toDTO()),
-            new VotingKeyDto(Convert.hexToUint8(this.linkedPublicKey)),
+            new VotingPublicKeyDto(Convert.hexToUint8(this.linkedPublicKey)),
             new FinalizationEpochDto(this.startEpoch),
             new FinalizationEpochDto(this.endEpoch),
             this.linkAction.valueOf(),
@@ -166,7 +166,7 @@ export class VotingKeyLinkTransaction extends Transaction {
             this.versionToDTO(),
             this.networkType.valueOf(),
             TransactionType.VOTING_KEY_LINK.valueOf(),
-            new VotingKeyDto(Convert.hexToUint8(this.linkedPublicKey)),
+            new VotingPublicKeyDto(Convert.hexToUint8(this.linkedPublicKey)),
             new FinalizationEpochDto(this.startEpoch),
             new FinalizationEpochDto(this.endEpoch),
             this.linkAction.valueOf(),

--- a/src/model/transaction/VrfKeyLinkTransaction.ts
+++ b/src/model/transaction/VrfKeyLinkTransaction.ts
@@ -18,7 +18,7 @@ import {
     AmountDto,
     EmbeddedTransactionBuilder,
     EmbeddedVrfKeyLinkTransactionBuilder,
-    KeyDto,
+    PublicKeyDto,
     TimestampDto,
     TransactionBuilder,
     VrfKeyLinkTransactionBuilder,
@@ -111,12 +111,12 @@ export class VrfKeyLinkTransaction extends Transaction {
         const builder = isEmbedded
             ? EmbeddedVrfKeyLinkTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload))
             : VrfKeyLinkTransactionBuilder.loadFromBinary(Convert.hexToUint8(payload));
-        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().key);
+        const signerPublicKey = Convert.uint8ToHex(builder.getSignerPublicKey().publicKey);
         const networkType = builder.getNetwork().valueOf();
         const signature = Transaction.getSignatureFromPayload(payload, isEmbedded);
         const transaction = VrfKeyLinkTransaction.create(
             isEmbedded ? Deadline.createEmtpy() : Deadline.createFromDTO((builder as VrfKeyLinkTransactionBuilder).getDeadline().timestamp),
-            Convert.uint8ToHex(builder.getLinkedPublicKey().key),
+            Convert.uint8ToHex(builder.getLinkedPublicKey().publicKey),
             builder.getLinkAction().valueOf(),
             networkType,
             isEmbedded ? new UInt64([0, 0]) : new UInt64((builder as VrfKeyLinkTransactionBuilder).fee.amount),
@@ -139,7 +139,7 @@ export class VrfKeyLinkTransaction extends Transaction {
             TransactionType.VRF_KEY_LINK.valueOf(),
             new AmountDto(this.maxFee.toDTO()),
             new TimestampDto(this.deadline.toDTO()),
-            new KeyDto(Convert.hexToUint8(this.linkedPublicKey)),
+            new PublicKeyDto(Convert.hexToUint8(this.linkedPublicKey)),
             this.linkAction.valueOf(),
         );
         return transactionBuilder;
@@ -155,7 +155,7 @@ export class VrfKeyLinkTransaction extends Transaction {
             this.versionToDTO(),
             this.networkType.valueOf(),
             TransactionType.VRF_KEY_LINK.valueOf(),
-            new KeyDto(Convert.hexToUint8(this.linkedPublicKey)),
+            new PublicKeyDto(Convert.hexToUint8(this.linkedPublicKey)),
             this.linkAction.valueOf(),
         );
     }

--- a/test/model/transaction/AccountMetadataTransaction.spec.ts
+++ b/test/model/transaction/AccountMetadataTransaction.spec.ts
@@ -131,7 +131,7 @@ describe('AccountMetadataTransaction', () => {
         const embedded = accountMetadataTransaction.toEmbeddedTransaction();
 
         expect(embedded).to.be.instanceOf(EmbeddedTransactionBuilder);
-        expect(Convert.uint8ToHex(embedded.signerPublicKey.key)).to.be.equal(account.publicKey);
+        expect(Convert.uint8ToHex(embedded.signerPublicKey.publicKey)).to.be.equal(account.publicKey);
         expect(embedded.type.valueOf()).to.be.equal(TransactionType.ACCOUNT_METADATA.valueOf());
     });
 

--- a/test/model/transaction/MosaicAliasTransaction.spec.ts
+++ b/test/model/transaction/MosaicAliasTransaction.spec.ts
@@ -188,7 +188,7 @@ describe('MosaicAliasTransaction', () => {
         const embedded = mosaicAliasTransaction.toEmbeddedTransaction();
 
         expect(embedded).to.be.instanceOf(EmbeddedTransactionBuilder);
-        expect(Convert.uint8ToHex(embedded.signerPublicKey.key)).to.be.equal(account.publicKey);
+        expect(Convert.uint8ToHex(embedded.signerPublicKey.publicKey)).to.be.equal(account.publicKey);
         expect(embedded.type.valueOf()).to.be.equal(TransactionType.MOSAIC_ALIAS.valueOf());
     });
 

--- a/test/model/transaction/MosaicMetadataTransaction.spec.ts
+++ b/test/model/transaction/MosaicMetadataTransaction.spec.ts
@@ -206,7 +206,7 @@ describe('MosaicMetadataTransaction', () => {
         const embedded = mosaicMetadataTransaction.toEmbeddedTransaction();
 
         expect(embedded).to.be.instanceOf(EmbeddedTransactionBuilder);
-        expect(Convert.uint8ToHex(embedded.signerPublicKey.key)).to.be.equal(account.publicKey);
+        expect(Convert.uint8ToHex(embedded.signerPublicKey.publicKey)).to.be.equal(account.publicKey);
         expect(embedded.type.valueOf()).to.be.equal(TransactionType.MOSAIC_METADATA.valueOf());
     });
 

--- a/test/model/transaction/NamespaceMetadataTransaction.spec.ts
+++ b/test/model/transaction/NamespaceMetadataTransaction.spec.ts
@@ -144,7 +144,7 @@ describe('NamespaceMetadataTransaction', () => {
         const embedded = namespaceMetadataTransaction.toEmbeddedTransaction();
 
         expect(embedded).to.be.instanceOf(EmbeddedTransactionBuilder);
-        expect(Convert.uint8ToHex(embedded.signerPublicKey.key)).to.be.equal(account.publicKey);
+        expect(Convert.uint8ToHex(embedded.signerPublicKey.publicKey)).to.be.equal(account.publicKey);
         expect(embedded.type.valueOf()).to.be.equal(TransactionType.NAMESPACE_METADATA.valueOf());
     });
 

--- a/test/model/transaction/SecretProofTransaction.spec.ts
+++ b/test/model/transaction/SecretProofTransaction.spec.ts
@@ -272,7 +272,7 @@ describe('SecretProofTransaction', () => {
         const embedded = secretProofTransaction.toEmbeddedTransaction();
 
         expect(embedded).to.be.instanceOf(EmbeddedTransactionBuilder);
-        expect(Convert.uint8ToHex(embedded.signerPublicKey.key)).to.be.equal(account.publicKey);
+        expect(Convert.uint8ToHex(embedded.signerPublicKey.publicKey)).to.be.equal(account.publicKey);
         expect(embedded.type.valueOf()).to.be.equal(TransactionType.SECRET_PROOF.valueOf());
     });
 


### PR DESCRIPTION
fix: Upgraded catbuffer to generated classes using the latest schema names

The latest catbuffer schema and parsers changed a few names, mostly from Key -> PublicKey. This PR reflects the changes required to use new generated classes.

The new catbuffer lib is the one generated in https://github.com/symbol/catbuffer-generators/pull/166

Note: Revokable mosaic support would be added in another PR.