### PR TITLE
fix: node js upgrade to 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 dist: bionic
 language: node_js
 node_js:
-  - 10
   - 12
+  - lts/*
+  - node
 services:
   - docker
 env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,9 @@
                 "typedoc": "^0.20.36",
                 "typescript": "^3.9.7",
                 "typescript-require": "^0.2.10"
+            },
+            "engines": {
+                "node": ">=12.22.1"
             }
         },
         "../symbol-openapi-generator/build/symbol-openapi-typescript-fetch-client": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,9 @@
     "homepage": "https://github.com/nemtech/symbol-sdk-typescript-javascript#readme",
     "main": "dist/index.js",
     "typings": "dist/index.d.ts",
+    "engines": {
+        "node": ">=12.22.1"
+    },
     "devDependencies": {
         "@types/chai": "^4.2.12",
         "@types/lodash": "^4.14.161",


### PR DESCRIPTION
I'm doing several upgrades, first upgrade is node js 12. The rest, typescript 4, eslint 8, rxjs 7 will follow