### PR TITLE
fix: metadata value non-ascii utf8 encoding issue fixed

### DIFF
--- a/e2e/infrastructure/MetadataHttp.spec.ts
+++ b/e2e/infrastructure/MetadataHttp.spec.ts
@@ -18,6 +18,7 @@ import { deepEqual } from 'assert';
 import { expect } from 'chai';
 import { firstValueFrom } from 'rxjs';
 import { take, toArray } from 'rxjs/operators';
+import { Convert } from '../..';
 import { MetadataPaginationStreamer, MetadataRepository, Order } from '../../src/infrastructure';
 import { Metadata, MetadataType, UInt64 } from '../../src/model';
 import { Account, Address } from '../../src/model/account';
@@ -115,7 +116,7 @@ describe('MetadataHttp', () => {
                 account.address,
                 UInt64.fromUint(6),
                 23,
-                `Test account meta value`,
+                Convert.utf8ToUint8(`Test account meta value`),
                 networkType,
                 helper.maxFee,
             );

--- a/e2e/infrastructure/MetadataHttp.spec.ts
+++ b/e2e/infrastructure/MetadataHttp.spec.ts
@@ -141,7 +141,7 @@ describe('MetadataHttp', () => {
                 UInt64.fromUint(6),
                 mosaicId,
                 22,
-                `Test mosaic meta value`,
+                Convert.utf8ToUint8(`Test mosaic meta value`),
                 networkType,
                 helper.maxFee,
             );
@@ -166,7 +166,7 @@ describe('MetadataHttp', () => {
                 UInt64.fromUint(6),
                 namespaceId,
                 25,
-                `Test namespace meta value`,
+                Convert.utf8ToUint8(`Test namespace meta value`),
                 networkType,
                 helper.maxFee,
             );

--- a/e2e/infrastructure/TransactionHttp.spec.ts
+++ b/e2e/infrastructure/TransactionHttp.spec.ts
@@ -196,7 +196,7 @@ describe('TransactionHttp', () => {
                 account.address,
                 UInt64.fromUint(5),
                 10,
-                Convert.uint8ToUtf8(new Uint8Array(10)),
+                new Uint8Array(10),
                 networkType,
                 helper.maxFee,
             );

--- a/e2e/infrastructure/TransactionHttp.spec.ts
+++ b/e2e/infrastructure/TransactionHttp.spec.ts
@@ -229,7 +229,7 @@ describe('TransactionHttp', () => {
                 UInt64.fromUint(5),
                 mosaicId,
                 10,
-                Convert.uint8ToUtf8(new Uint8Array(10)),
+                new Uint8Array(10),
                 networkType,
                 helper.maxFee,
             );
@@ -323,7 +323,7 @@ describe('TransactionHttp', () => {
                 UInt64.fromUint(5),
                 addressAlias,
                 10,
-                Convert.uint8ToUtf8(new Uint8Array(10)),
+                new Uint8Array(10),
                 networkType,
                 helper.maxFee,
             );

--- a/e2e/infrastructure/UnresolvedMapping.spec.ts
+++ b/e2e/infrastructure/UnresolvedMapping.spec.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import { expect } from 'chai';
-import { Convert } from '../../src/core/format';
 import { Account } from '../../src/model/account';
 import { PlainMessage } from '../../src/model/message/PlainMessage';
 import { MosaicFlags, MosaicId, MosaicNonce } from '../../src/model/mosaic';
@@ -165,7 +164,7 @@ describe('Unresolved Mapping', () => {
                 UInt64.fromUint(5),
                 namespaceIdMosaic,
                 10,
-                Convert.uint8ToUtf8(new Uint8Array(10)),
+                new Uint8Array(10),
                 networkType,
                 helper.maxFee,
             );

--- a/e2e/service/MetadataTransactionService.spec.ts
+++ b/e2e/service/MetadataTransactionService.spec.ts
@@ -95,7 +95,7 @@ describe('MetadataTransactionService', () => {
                 key,
                 mosaicId,
                 newValue.length,
-                newValue,
+                Convert.utf8ToUint8(newValue),
                 networkType,
                 helper.maxFee,
             );
@@ -121,7 +121,7 @@ describe('MetadataTransactionService', () => {
                 key,
                 namespaceId,
                 newValue.length,
-                newValue,
+                Convert.utf8ToUint8(newValue),
                 networkType,
             );
 

--- a/e2e/service/TransactionService.spec.ts
+++ b/e2e/service/TransactionService.spec.ts
@@ -16,7 +16,6 @@
 
 import { assert, expect } from 'chai';
 import { firstValueFrom } from 'rxjs';
-import { Convert } from '../../src/core/format';
 import { TransactionRepository } from '../../src/infrastructure/TransactionRepository';
 import { Account, Address } from '../../src/model/account';
 import { PlainMessage } from '../../src/model/message/PlainMessage';
@@ -136,7 +135,7 @@ describe('TransactionService', () => {
             UInt64.fromUint(5),
             mosaicAlias,
             10,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             networkType,
             helper.maxFee,
         );

--- a/src/core/format/Convert.ts
+++ b/src/core/format/Convert.ts
@@ -190,7 +190,7 @@ export class Convert {
      * @return {Uint8Array}
      */
     public static utf8ToUint8 = (input: string): Uint8Array => {
-        const hex = Convert.utf8ToHex(Convert.rstr2utf8(input));
+        const hex = Convert.utf8ToHex(input);
         return Convert.hexToUint8(hex);
     };
 

--- a/src/core/format/Convert.ts
+++ b/src/core/format/Convert.ts
@@ -26,7 +26,7 @@ export class Convert {
     public static toByte = (char1: string, char2: string): number => {
         const byte = utilities.tryParseByte(char1, char2);
         if (undefined === byte) {
-            throw Error(`unrecognized hex char`);
+            throw Error(`unrecognized hex char, char1:${char1}, char2:${char2}`);
         }
         return byte;
     };
@@ -146,33 +146,6 @@ export class Convert {
             throw Error(`input '${input}' is out of range`);
         }
         return input & 0xff;
-    };
-
-    /**
-     * Converts a raw javascript string into a string of single byte characters using utf8 encoding.
-     * This makes it easier to perform other encoding operations on the string.
-     * @param {string} input - A raw string
-     * @return {string} - UTF-8 string
-     */
-    public static rstr2utf8 = (input: string): string => {
-        let output = '';
-
-        for (let n = 0; n < input.length; n++) {
-            const c = input.charCodeAt(n);
-
-            if (128 > c) {
-                output += String.fromCharCode(c);
-            } else if (127 < c && 2048 > c) {
-                output += String.fromCharCode((c >> 6) | 192);
-                output += String.fromCharCode((c & 63) | 128);
-            } else {
-                output += String.fromCharCode((c >> 12) | 224);
-                output += String.fromCharCode(((c >> 6) & 63) | 128);
-                output += String.fromCharCode((c & 63) | 128);
-            }
-        }
-
-        return output;
     };
 
     /**

--- a/src/infrastructure/transaction/CreateTransactionFromDTO.ts
+++ b/src/infrastructure/transaction/CreateTransactionFromDTO.ts
@@ -393,7 +393,7 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
                 extractRecipient(transactionDTO.targetAddress),
                 UInt64.fromHex(transactionDTO.scopedMetadataKey),
                 transactionDTO.valueSizeDelta,
-                convert.decodeHex(transactionDTO.value),
+                convert.utf8ToUint8(transactionDTO.value),
                 signature,
                 signer,
                 transactionInfo,

--- a/src/infrastructure/transaction/CreateTransactionFromDTO.ts
+++ b/src/infrastructure/transaction/CreateTransactionFromDTO.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Convert as convert } from '../../core/format';
 import { UnresolvedMapping } from '../../core/utils';
 import { MessageFactory, MosaicSupplyRevocationTransaction, UInt64 } from '../../model';
 import { Address, PublicAccount } from '../../model/account';
@@ -393,7 +392,7 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
                 extractRecipient(transactionDTO.targetAddress),
                 UInt64.fromHex(transactionDTO.scopedMetadataKey),
                 transactionDTO.valueSizeDelta,
-                convert.utf8ToUint8(transactionDTO.value),
+                transactionDTO.value,
                 signature,
                 signer,
                 transactionInfo,
@@ -408,7 +407,7 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
                 UInt64.fromHex(transactionDTO.scopedMetadataKey),
                 UnresolvedMapping.toUnresolvedMosaic(transactionDTO.targetMosaicId),
                 transactionDTO.valueSizeDelta,
-                convert.decodeHex(transactionDTO.value),
+                transactionDTO.value,
                 signature,
                 signer,
                 transactionInfo,
@@ -423,7 +422,7 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
                 UInt64.fromHex(transactionDTO.scopedMetadataKey),
                 NamespaceId.createFromEncoded(transactionDTO.targetNamespaceId),
                 transactionDTO.valueSizeDelta,
-                convert.decodeHex(transactionDTO.value),
+                transactionDTO.value,
                 signature,
                 signer,
                 transactionInfo,

--- a/src/infrastructure/transaction/SerializeTransactionToJSON.ts
+++ b/src/infrastructure/transaction/SerializeTransactionToJSON.ts
@@ -246,7 +246,7 @@ export const SerializeTransactionToJSON = (transaction: Transaction): any => {
             scopedMetadataKey: accountMetadataTx.scopedMetadataKey.toHex(),
             valueSizeDelta: accountMetadataTx.valueSizeDelta,
             valueSize: accountMetadataTx.value.length,
-            value: Convert.utf8ToHex(accountMetadataTx.value),
+            value: accountMetadataTx.value,
         };
     } else if (transaction.type === TransactionType.MOSAIC_METADATA) {
         const mosaicMetadataTx = transaction as MosaicMetadataTransaction;

--- a/src/infrastructure/transaction/SerializeTransactionToJSON.ts
+++ b/src/infrastructure/transaction/SerializeTransactionToJSON.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { Convert } from '../../core/format';
 import {
     AccountAddressRestrictionTransaction,
     AccountKeyLinkTransaction,
@@ -256,7 +255,7 @@ export const SerializeTransactionToJSON = (transaction: Transaction): any => {
             valueSizeDelta: mosaicMetadataTx.valueSizeDelta,
             targetMosaicId: mosaicMetadataTx.targetMosaicId.id.toHex(),
             valueSize: mosaicMetadataTx.value.length,
-            value: Convert.utf8ToHex(mosaicMetadataTx.value),
+            value: mosaicMetadataTx.value,
         };
     } else if (transaction.type === TransactionType.NAMESPACE_METADATA) {
         const namespaceMetaTx = transaction as NamespaceMetadataTransaction;
@@ -266,7 +265,7 @@ export const SerializeTransactionToJSON = (transaction: Transaction): any => {
             valueSizeDelta: namespaceMetaTx.valueSizeDelta,
             targetNamespaceId: namespaceMetaTx.targetNamespaceId.id.toHex(),
             valueSize: namespaceMetaTx.value.length,
-            value: Convert.utf8ToHex(namespaceMetaTx.value),
+            value: namespaceMetaTx.value,
         };
     } else if (transaction.type === TransactionType.VRF_KEY_LINK) {
         const vrfKeyLinkTx = transaction as VrfKeyLinkTransaction;

--- a/src/model/transaction/AccountMetadataTransaction.ts
+++ b/src/model/transaction/AccountMetadataTransaction.ts
@@ -46,8 +46,7 @@ export class AccountMetadataTransaction extends Transaction {
      * @param targetAddress - target account address.
      * @param scopedMetadataKey - Metadata key scoped to source, target and type.
      * @param valueSizeDelta - Change in value size in bytes.
-     * @param value - String value with UTF-8 encoding
-     *                Difference between the previous value and new value.
+     * @param value - Difference between the previous value and new value.
      *                You can calculate value as xor(previous-value, new-value).
      *                If there is no previous value, use directly the new value.
      * @param maxFee - (Optional) Max fee defined by the sender

--- a/src/model/transaction/AccountMetadataTransaction.ts
+++ b/src/model/transaction/AccountMetadataTransaction.ts
@@ -60,7 +60,7 @@ export class AccountMetadataTransaction extends Transaction {
         targetAddress: UnresolvedAddress,
         scopedMetadataKey: UInt64,
         valueSizeDelta: number,
-        value: string,
+        value: Uint8Array,
         networkType: NetworkType,
         maxFee: UInt64 = new UInt64([0, 0]),
         signature?: string,
@@ -111,10 +111,10 @@ export class AccountMetadataTransaction extends Transaction {
          */
         public readonly valueSizeDelta: number,
         /**
-         * String value with UTF-8 encoding.
+         * xor of previous and the new value
          * Difference between the previous value and new value.
          */
-        public readonly value: string,
+        public readonly value: Uint8Array,
         signature?: string,
         signer?: PublicAccount,
         transactionInfo?: TransactionInfo,
@@ -142,7 +142,7 @@ export class AccountMetadataTransaction extends Transaction {
             UnresolvedMapping.toUnresolvedAddress(Convert.uint8ToHex(builder.getTargetAddress().unresolvedAddress)),
             new UInt64(builder.getScopedMetadataKey()),
             builder.getValueSizeDelta(),
-            Convert.uint8ToUtf8(builder.getValue()),
+            builder.getValue(),
             networkType,
             isEmbedded ? new UInt64([0, 0]) : new UInt64((builder as AccountMetadataTransactionBuilder).fee.amount),
             signature,
@@ -167,7 +167,7 @@ export class AccountMetadataTransaction extends Transaction {
             new UnresolvedAddressDto(this.targetAddress.encodeUnresolvedAddress(this.networkType)),
             this.scopedMetadataKey.toDTO(),
             this.valueSizeDelta,
-            Convert.utf8ToUint8(this.value),
+            this.value,
         );
         return transactionBuilder;
     }
@@ -185,7 +185,7 @@ export class AccountMetadataTransaction extends Transaction {
             new UnresolvedAddressDto(this.targetAddress.encodeUnresolvedAddress(this.networkType)),
             this.scopedMetadataKey.toDTO(),
             this.valueSizeDelta,
-            Convert.utf8ToUint8(this.value),
+            this.value,
         );
     }
 

--- a/src/model/transaction/MosaicMetadataTransaction.ts
+++ b/src/model/transaction/MosaicMetadataTransaction.ts
@@ -51,8 +51,7 @@ export class MosaicMetadataTransaction extends Transaction {
      * @param scopedMetadataKey - Metadata key scoped to source, target and type.
      * @param targetMosaicId - Target unresolved mosaic identifier.
      * @param valueSizeDelta - Change in value size in bytes.
-     * @param value - String value with UTF-8 encoding
-     *                Difference between the previous value and new value.
+     * @param value - Difference between the previous value and new value.
      *                You can calculate value as xor(previous-value, new-value).
      *                If there is no previous value, use directly the new value.
      * @param maxFee - (Optional) Max fee defined by the sender
@@ -66,7 +65,7 @@ export class MosaicMetadataTransaction extends Transaction {
         scopedMetadataKey: UInt64,
         targetMosaicId: UnresolvedMosaicId,
         valueSizeDelta: number,
-        value: string,
+        value: Uint8Array,
         networkType: NetworkType,
         maxFee: UInt64 = new UInt64([0, 0]),
         signature?: string,
@@ -123,10 +122,10 @@ export class MosaicMetadataTransaction extends Transaction {
          */
         public readonly valueSizeDelta: number,
         /**
-         * String value with UTF-8 encoding.
+         * xor of previous and the new value
          * Difference between the previous value and new value.
          */
-        public readonly value: string,
+        public readonly value: Uint8Array,
         signature?: string,
         signer?: PublicAccount,
         transactionInfo?: TransactionInfo,
@@ -155,7 +154,7 @@ export class MosaicMetadataTransaction extends Transaction {
             new UInt64(builder.getScopedMetadataKey()),
             UnresolvedMapping.toUnresolvedMosaic(new UInt64(builder.getTargetMosaicId().unresolvedMosaicId).toHex()),
             builder.getValueSizeDelta(),
-            Convert.uint8ToUtf8(builder.getValue()),
+            builder.getValue(),
             networkType,
             isEmbedded ? new UInt64([0, 0]) : new UInt64((builder as MosaicMetadataTransactionBuilder).fee.amount),
             signature,
@@ -181,7 +180,7 @@ export class MosaicMetadataTransaction extends Transaction {
             this.scopedMetadataKey.toDTO(),
             new UnresolvedMosaicIdDto(this.targetMosaicId.id.toDTO()),
             this.valueSizeDelta,
-            Convert.utf8ToUint8(this.value),
+            this.value,
         );
         return transactionBuilder;
     }
@@ -200,7 +199,7 @@ export class MosaicMetadataTransaction extends Transaction {
             this.scopedMetadataKey.toDTO(),
             new UnresolvedMosaicIdDto(this.targetMosaicId.id.toDTO()),
             this.valueSizeDelta,
-            Convert.utf8ToUint8(this.value),
+            this.value,
         );
     }
 

--- a/src/model/transaction/NamespaceMetadataTransaction.ts
+++ b/src/model/transaction/NamespaceMetadataTransaction.ts
@@ -48,8 +48,7 @@ export class NamespaceMetadataTransaction extends Transaction {
      * @param scopedMetadataKey - Metadata key scoped to source, target and type.
      * @param targetNamespaceId - Target namespace identifier.
      * @param valueSizeDelta - Change in value size in bytes.
-     * @param value - String value with UTF-8 encoding
-     *                Difference between the previous value and new value.
+     * @param value - Difference between the previous value and new value.
      *                You can calculate value as xor(previous-value, new-value).
      *                If there is no previous value, use directly the new value.
      * @param maxFee - (Optional) Max fee defined by the sender
@@ -63,7 +62,7 @@ export class NamespaceMetadataTransaction extends Transaction {
         scopedMetadataKey: UInt64,
         targetNamespaceId: NamespaceId,
         valueSizeDelta: number,
-        value: string,
+        value: Uint8Array,
         networkType: NetworkType,
         maxFee: UInt64 = new UInt64([0, 0]),
         signature?: string,
@@ -120,10 +119,10 @@ export class NamespaceMetadataTransaction extends Transaction {
          */
         public readonly valueSizeDelta: number,
         /**
-         * String value with UTF-8 encoding.
+         * xor of previous and the new value
          * Difference between the previous value and new value.
          */
-        public readonly value: string,
+        public readonly value: Uint8Array,
         signature?: string,
         signer?: PublicAccount,
         transactionInfo?: TransactionInfo,
@@ -152,7 +151,7 @@ export class NamespaceMetadataTransaction extends Transaction {
             new UInt64(builder.getScopedMetadataKey()),
             new NamespaceId(builder.getTargetNamespaceId().namespaceId),
             builder.getValueSizeDelta(),
-            Convert.uint8ToUtf8(builder.getValue()),
+            builder.getValue(),
             networkType,
             isEmbedded ? new UInt64([0, 0]) : new UInt64((builder as NamespaceMetadataTransactionBuilder).fee.amount),
             signature,
@@ -178,7 +177,7 @@ export class NamespaceMetadataTransaction extends Transaction {
             this.scopedMetadataKey.toDTO(),
             this.targetNamespaceId.toBuilder(),
             this.valueSizeDelta,
-            Convert.utf8ToUint8(this.value),
+            this.value,
         );
         return transactionBuilder;
     }
@@ -197,7 +196,7 @@ export class NamespaceMetadataTransaction extends Transaction {
             this.scopedMetadataKey.toDTO(),
             this.targetNamespaceId.toBuilder(),
             this.valueSizeDelta,
-            Convert.utf8ToUint8(this.value),
+            this.value,
         );
     }
 

--- a/src/service/MetadataTransactionService.ts
+++ b/src/service/MetadataTransactionService.ts
@@ -128,13 +128,15 @@ export class MetadataTransactionService {
                         const metadata = metadatas.data[0];
                         const currentValueByte = Convert.utf8ToUint8(metadata.metadataEntry.value);
                         const newValueBytes = Convert.utf8ToUint8(value);
+                        const xoredBytes = Convert.hexToUint8(Convert.xor(currentValueByte, newValueBytes));
+
                         return MosaicMetadataTransaction.create(
                             deadline,
                             targetAddress,
                             key,
                             mosaicId,
                             newValueBytes.length - currentValueByte.length,
-                            Convert.decodeHex(Convert.xor(currentValueByte, newValueBytes)),
+                            xoredBytes,
                             networkType,
                             maxFee,
                         );
@@ -146,7 +148,7 @@ export class MetadataTransactionService {
                         key,
                         mosaicId,
                         newValueBytes.length,
-                        value,
+                        Convert.utf8ToUint8(value),
                         networkType,
                         maxFee,
                     );
@@ -192,13 +194,14 @@ export class MetadataTransactionService {
                         const metadata = metadatas.data[0];
                         const currentValueByte = Convert.utf8ToUint8(metadata.metadataEntry.value);
                         const newValueBytes = Convert.utf8ToUint8(value);
+                        const xoredBytes = Convert.hexToUint8(Convert.xor(currentValueByte, newValueBytes));
                         return NamespaceMetadataTransaction.create(
                             deadline,
                             targetAddress,
                             key,
                             namespaceId,
                             newValueBytes.length - currentValueByte.length,
-                            Convert.decodeHex(Convert.xor(currentValueByte, newValueBytes)),
+                            xoredBytes,
                             networkType,
                             maxFee,
                         );
@@ -210,7 +213,7 @@ export class MetadataTransactionService {
                         key,
                         namespaceId,
                         newValueBytes.length,
-                        value,
+                        Convert.utf8ToUint8(value),
                         networkType,
                         maxFee,
                     );

--- a/src/service/MetadataTransactionService.ts
+++ b/src/service/MetadataTransactionService.ts
@@ -69,12 +69,14 @@ export class MetadataTransactionService {
                         const metadata = metadatas.data[0];
                         const currentValueByte = Convert.utf8ToUint8(metadata.metadataEntry.value);
                         const newValueBytes = Convert.utf8ToUint8(value);
+                        const xoredBytes = Convert.hexToUint8(Convert.xor(currentValueByte, newValueBytes));
+
                         return AccountMetadataTransaction.create(
                             deadline,
                             targetAddress,
                             key,
                             newValueBytes.length - currentValueByte.length,
-                            Convert.decodeHex(Convert.xor(currentValueByte, newValueBytes)),
+                            xoredBytes,
                             networkType,
                             maxFee,
                         );
@@ -85,7 +87,7 @@ export class MetadataTransactionService {
                         targetAddress,
                         key,
                         newValueBytes.length,
-                        value,
+                        Convert.utf8ToUint8(value),
                         networkType,
                         maxFee,
                     );

--- a/test/core/format/Convert.spec.ts
+++ b/test/core/format/Convert.spec.ts
@@ -407,7 +407,7 @@ describe('convert', () => {
         });
     });
 
-    describe('utf8ToUni8', () => {
+    describe('utf8ToUint8', () => {
         it('should convert numeric string to Uint8Array', () => {
             const actual = '123456789';
             // Act:
@@ -428,6 +428,16 @@ describe('convert', () => {
             expect(uint.length).to.be.equal(actual.length);
             expect(convert.uint8ToHex(uint)).to.be.equal('74657374');
         });
+
+        it('should convert non-ascii utf8 string to Uint8Array', () => {
+            const actual = '存在';
+            // Act:
+            const uint = convert.utf8ToUint8(actual);
+
+            // Assert:
+            expect(uint.length).to.be.equal(6);
+            expect(convert.uint8ToHex(uint)).to.be.equal('E5AD98E59CA8');
+        });
     });
 
     describe('uint8ToUtf8', () => {
@@ -443,6 +453,16 @@ describe('convert', () => {
 
         it('should convert Uint8Array to utf8 string ', () => {
             const expected = 'test';
+            const actual = convert.utf8ToUint8(expected);
+            // Act:
+            const result = convert.uint8ToUtf8(actual);
+
+            // Assert:
+            expect(result).to.be.equal(expected);
+        });
+
+        it('should convert Uint8Array to non-ascii utf8 string ', () => {
+            const expected = '存在';
             const actual = convert.utf8ToUint8(expected);
             // Act:
             const result = convert.uint8ToUtf8(actual);

--- a/test/core/utils/TransactionMapping.spec.ts
+++ b/test/core/utils/TransactionMapping.spec.ts
@@ -523,7 +523,7 @@ describe('TransactionMapping - createFromPayload', () => {
             account.address,
             UInt64.fromUint(1000),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
         const mosaicMetadataTransaction = MosaicMetadataTransaction.create(
@@ -872,7 +872,7 @@ describe('TransactionMapping - createFromPayload', () => {
             account.address,
             UInt64.fromUint(1000),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
 
@@ -1552,7 +1552,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
             account.address,
             UInt64.fromUint(1000),
             1,
-            'Test Value',
+            Convert.utf8ToUint8('Test Value'),
             TestNetworkType,
         );
 
@@ -1566,7 +1566,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
         expect(transaction.targetAddress.equals(account.address)).to.be.true;
         expect(transaction.scopedMetadataKey.toHex()).to.be.equal(UInt64.fromUint(1000).toHex());
         expect(transaction.valueSizeDelta).to.be.equal(1);
-        expect(transaction.value).to.be.equal('Test Value');
+        expect(Convert.uint8ToHex(transaction.value)).to.be.equal(Convert.utf8ToHex('Test Value'));
     });
 
     it('should create MosaicMetadataTransaction', () => {

--- a/test/core/utils/TransactionMapping.spec.ts
+++ b/test/core/utils/TransactionMapping.spec.ts
@@ -532,7 +532,7 @@ describe('TransactionMapping - createFromPayload', () => {
             UInt64.fromUint(1000),
             new MosaicId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
         const namespaceMetadataTransaction = NamespaceMetadataTransaction.create(
@@ -541,7 +541,7 @@ describe('TransactionMapping - createFromPayload', () => {
             UInt64.fromUint(1000),
             new NamespaceId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
 
@@ -899,7 +899,7 @@ describe('TransactionMapping - createFromPayload', () => {
             UInt64.fromUint(1000),
             new MosaicId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
 
@@ -927,7 +927,7 @@ describe('TransactionMapping - createFromPayload', () => {
             UInt64.fromUint(1000),
             new NamespaceId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
 
@@ -1576,7 +1576,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
             UInt64.fromUint(1000),
             new MosaicId([2262289484, 3405110546]),
             1,
-            'Test Value',
+            Convert.utf8ToUint8('Test Value'),
             TestNetworkType,
         );
 
@@ -1591,7 +1591,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
         expect(transaction.scopedMetadataKey.toHex()).to.be.equal(UInt64.fromUint(1000).toHex());
         expect(transaction.valueSizeDelta).to.be.equal(1);
         expect(transaction.targetMosaicId.toHex()).to.be.equal(new MosaicId([2262289484, 3405110546]).toHex());
-        expect(transaction.value).to.be.equal('Test Value');
+        expect(Convert.uint8ToHex(transaction.value)).to.be.equal(Convert.utf8ToHex('Test Value'));
     });
 
     it('should create NamespaceMetadataTransaction', () => {
@@ -1601,7 +1601,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
             UInt64.fromUint(1000),
             new NamespaceId([2262289484, 3405110546]),
             1,
-            'Test Value',
+            Convert.utf8ToUint8('Test Value'),
             TestNetworkType,
         );
 
@@ -1616,7 +1616,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
         expect(transaction.scopedMetadataKey.toString()).to.be.equal(UInt64.fromUint(1000).toString());
         expect(transaction.valueSizeDelta).to.be.equal(1);
         expect(transaction.targetNamespaceId.toHex()).to.be.equal(new NamespaceId([2262289484, 3405110546]).toHex());
-        expect(transaction.value).to.be.equal('Test Value');
+        expect(Convert.uint8ToHex(transaction.value)).to.be.equal(Convert.utf8ToHex('Test Value'));
     });
 
     it('should create from payload with persistent delegate message', () => {

--- a/test/core/utils/TransactionMappingWithSignatures.spec.ts
+++ b/test/core/utils/TransactionMappingWithSignatures.spec.ts
@@ -543,7 +543,7 @@ describe('TransactionMapping - createFromPayload with optional sigature and sign
             UInt64.fromUint(1000),
             new MosaicId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             NetworkType.TEST_NET,
         );
         const namespaceMetadataTransaction = NamespaceMetadataTransaction.create(
@@ -552,7 +552,7 @@ describe('TransactionMapping - createFromPayload with optional sigature and sign
             UInt64.fromUint(1000),
             new NamespaceId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             NetworkType.TEST_NET,
         );
 
@@ -1002,7 +1002,7 @@ describe('TransactionMapping - createFromPayload with optional sigature and sign
             UInt64.fromUint(1000),
             new MosaicId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             NetworkType.TEST_NET,
             undefined,
             testSignature,
@@ -1037,7 +1037,7 @@ describe('TransactionMapping - createFromPayload with optional sigature and sign
             UInt64.fromUint(1000),
             new NamespaceId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             NetworkType.TEST_NET,
             undefined,
             testSignature,

--- a/test/core/utils/TransactionMappingWithSignatures.spec.ts
+++ b/test/core/utils/TransactionMappingWithSignatures.spec.ts
@@ -534,7 +534,7 @@ describe('TransactionMapping - createFromPayload with optional sigature and sign
             account.address,
             UInt64.fromUint(1000),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             NetworkType.TEST_NET,
         );
         const mosaicMetadataTransaction = MosaicMetadataTransaction.create(
@@ -969,7 +969,7 @@ describe('TransactionMapping - createFromPayload with optional sigature and sign
             account.address,
             UInt64.fromUint(1000),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             NetworkType.TEST_NET,
             undefined,
             testSignature,

--- a/test/model/transaction/AccountMetadataTransaction.spec.ts
+++ b/test/model/transaction/AccountMetadataTransaction.spec.ts
@@ -41,7 +41,7 @@ describe('AccountMetadataTransaction', () => {
             account.address,
             UInt64.fromUint(1000),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
 
@@ -55,7 +55,7 @@ describe('AccountMetadataTransaction', () => {
             account.address,
             UInt64.fromUint(1000),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
             new UInt64([1, 0]),
         );
@@ -70,7 +70,7 @@ describe('AccountMetadataTransaction', () => {
             account.address,
             UInt64.fromUint(1000),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
 
@@ -88,7 +88,7 @@ describe('AccountMetadataTransaction', () => {
                 account.address,
                 UInt64.fromUint(1000),
                 1,
-                Convert.uint8ToUtf8(new Uint8Array(10)),
+                new Uint8Array(10),
                 TestNetworkType,
             );
 
@@ -105,7 +105,7 @@ describe('AccountMetadataTransaction', () => {
                 account.address,
                 UInt64.fromUint(1000),
                 1,
-                Convert.uint8ToUtf8(new Uint8Array(10)),
+                new Uint8Array(10),
                 TestNetworkType,
             );
 
@@ -122,7 +122,7 @@ describe('AccountMetadataTransaction', () => {
             account.address,
             UInt64.fromUint(1000),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
 
@@ -141,7 +141,7 @@ describe('AccountMetadataTransaction', () => {
             account.address,
             UInt64.fromUint(1000),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
 
@@ -157,7 +157,7 @@ describe('AccountMetadataTransaction', () => {
             account.address,
             UInt64.fromUint(1000),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
 
@@ -179,7 +179,7 @@ describe('AccountMetadataTransaction', () => {
             alias,
             UInt64.fromUint(1000),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
 

--- a/test/model/transaction/AccountMetadataTransaction.spec.ts
+++ b/test/model/transaction/AccountMetadataTransaction.spec.ts
@@ -28,11 +28,14 @@ import { UInt64 } from '../../../src/model/UInt64';
 import { TestingAccount, TestNetworkType } from '../../conf/conf.spec';
 
 describe('AccountMetadataTransaction', () => {
-    let account: Account;
+    let account: Account, emptyValue: Uint8Array;
     const generationHash = '57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6';
     const epochAdjustment = 1573430400;
     before(() => {
         account = TestingAccount;
+    });
+    beforeEach(() => {
+        emptyValue = new Uint8Array(10);
     });
 
     it('should default maxFee field be set to 0', () => {
@@ -41,7 +44,7 @@ describe('AccountMetadataTransaction', () => {
             account.address,
             UInt64.fromUint(1000),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
         );
 
@@ -55,7 +58,7 @@ describe('AccountMetadataTransaction', () => {
             account.address,
             UInt64.fromUint(1000),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
             new UInt64([1, 0]),
         );
@@ -70,7 +73,7 @@ describe('AccountMetadataTransaction', () => {
             account.address,
             UInt64.fromUint(1000),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
         );
 
@@ -88,7 +91,7 @@ describe('AccountMetadataTransaction', () => {
                 account.address,
                 UInt64.fromUint(1000),
                 1,
-                new Uint8Array(10),
+                emptyValue,
                 TestNetworkType,
             );
 
@@ -105,7 +108,7 @@ describe('AccountMetadataTransaction', () => {
                 account.address,
                 UInt64.fromUint(1000),
                 1,
-                new Uint8Array(10),
+                emptyValue,
                 TestNetworkType,
             );
 
@@ -122,7 +125,7 @@ describe('AccountMetadataTransaction', () => {
             account.address,
             UInt64.fromUint(1000),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
         );
 
@@ -141,7 +144,7 @@ describe('AccountMetadataTransaction', () => {
             account.address,
             UInt64.fromUint(1000),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
         );
 
@@ -157,7 +160,7 @@ describe('AccountMetadataTransaction', () => {
             account.address,
             UInt64.fromUint(1000),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
         );
 
@@ -179,7 +182,7 @@ describe('AccountMetadataTransaction', () => {
             alias,
             UInt64.fromUint(1000),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
         );
 

--- a/test/model/transaction/MosaicMetadataTransaction.spec.ts
+++ b/test/model/transaction/MosaicMetadataTransaction.spec.ts
@@ -60,7 +60,7 @@ describe('MosaicMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new MosaicId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
 
@@ -75,7 +75,7 @@ describe('MosaicMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new MosaicId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
             new UInt64([1, 0]),
         );
@@ -91,7 +91,7 @@ describe('MosaicMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new MosaicId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
 
@@ -110,7 +110,7 @@ describe('MosaicMetadataTransaction', () => {
             UInt64.fromUint(1000),
             namespacId,
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
 
@@ -129,7 +129,7 @@ describe('MosaicMetadataTransaction', () => {
                 UInt64.fromUint(1000),
                 new MosaicId([2262289484, 3405110546]),
                 1,
-                Convert.uint8ToUtf8(new Uint8Array(10)),
+                new Uint8Array(10),
                 TestNetworkType,
             );
             expect(mosaicMetadataTransaction.size).to.be.equal(182);
@@ -143,7 +143,7 @@ describe('MosaicMetadataTransaction', () => {
                 UInt64.fromUint(1000),
                 new MosaicId([2262289484, 3405110546]),
                 1,
-                Convert.uint8ToUtf8(new Uint8Array(10)),
+                new Uint8Array(10),
                 TestNetworkType,
             );
             expect(mosaicMetadataTransaction.size).to.be.equal(182);
@@ -159,7 +159,7 @@ describe('MosaicMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new MosaicId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         ).setMaxFee(2);
         expect(mosaicMetadataTransaction.maxFee.compact()).to.be.equal(364);
@@ -178,7 +178,7 @@ describe('MosaicMetadataTransaction', () => {
             UInt64.fromUint(1000),
             unresolvedMosaicId,
             10,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             '',
             account.publicAccount,
             new TransactionInfo(UInt64.fromUint(2), 0, ''),
@@ -197,7 +197,7 @@ describe('MosaicMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new MosaicId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
 
@@ -217,7 +217,7 @@ describe('MosaicMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new MosaicId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
         let canNotify = tx.shouldNotifyAccount(account.address);
@@ -239,7 +239,7 @@ describe('MosaicMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new MosaicId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
         let canNotify = tx.shouldNotifyAccount(alias);

--- a/test/model/transaction/MosaicMetadataTransaction.spec.ts
+++ b/test/model/transaction/MosaicMetadataTransaction.spec.ts
@@ -34,7 +34,7 @@ import { UInt64 } from '../../../src/model/UInt64';
 import { TestingAccount, TestNetworkType } from '../../conf/conf.spec';
 
 describe('MosaicMetadataTransaction', () => {
-    let account: Account;
+    let account: Account, emptyValue: Uint8Array;
     const generationHash = '57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6';
     let statement: Statement;
     const unresolvedMosaicId = new NamespaceId('mosaic');
@@ -52,6 +52,9 @@ describe('MosaicMetadataTransaction', () => {
             ],
         );
     });
+    beforeEach(() => {
+        emptyValue = new Uint8Array(10);
+    });
 
     it('should default maxFee field be set to 0', () => {
         const mosaicMetadataTransaction = MosaicMetadataTransaction.create(
@@ -60,7 +63,7 @@ describe('MosaicMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new MosaicId([2262289484, 3405110546]),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
         );
 
@@ -75,7 +78,7 @@ describe('MosaicMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new MosaicId([2262289484, 3405110546]),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
             new UInt64([1, 0]),
         );
@@ -91,7 +94,7 @@ describe('MosaicMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new MosaicId([2262289484, 3405110546]),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
         );
 
@@ -110,7 +113,7 @@ describe('MosaicMetadataTransaction', () => {
             UInt64.fromUint(1000),
             namespacId,
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
         );
 
@@ -129,7 +132,7 @@ describe('MosaicMetadataTransaction', () => {
                 UInt64.fromUint(1000),
                 new MosaicId([2262289484, 3405110546]),
                 1,
-                new Uint8Array(10),
+                emptyValue,
                 TestNetworkType,
             );
             expect(mosaicMetadataTransaction.size).to.be.equal(182);
@@ -143,7 +146,7 @@ describe('MosaicMetadataTransaction', () => {
                 UInt64.fromUint(1000),
                 new MosaicId([2262289484, 3405110546]),
                 1,
-                new Uint8Array(10),
+                emptyValue,
                 TestNetworkType,
             );
             expect(mosaicMetadataTransaction.size).to.be.equal(182);
@@ -159,7 +162,7 @@ describe('MosaicMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new MosaicId([2262289484, 3405110546]),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
         ).setMaxFee(2);
         expect(mosaicMetadataTransaction.maxFee.compact()).to.be.equal(364);
@@ -178,7 +181,7 @@ describe('MosaicMetadataTransaction', () => {
             UInt64.fromUint(1000),
             unresolvedMosaicId,
             10,
-            new Uint8Array(10),
+            emptyValue,
             '',
             account.publicAccount,
             new TransactionInfo(UInt64.fromUint(2), 0, ''),
@@ -197,7 +200,7 @@ describe('MosaicMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new MosaicId([2262289484, 3405110546]),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
         );
 
@@ -217,7 +220,7 @@ describe('MosaicMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new MosaicId([2262289484, 3405110546]),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
         );
         let canNotify = tx.shouldNotifyAccount(account.address);
@@ -239,7 +242,7 @@ describe('MosaicMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new MosaicId([2262289484, 3405110546]),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
         );
         let canNotify = tx.shouldNotifyAccount(alias);

--- a/test/model/transaction/NamespaceMetadataTransaction.spec.ts
+++ b/test/model/transaction/NamespaceMetadataTransaction.spec.ts
@@ -39,7 +39,7 @@ describe('NamespaceMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new NamespaceId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
 
@@ -54,7 +54,7 @@ describe('NamespaceMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new NamespaceId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
             new UInt64([1, 0]),
         );
@@ -70,7 +70,7 @@ describe('NamespaceMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new NamespaceId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
 
@@ -89,7 +89,7 @@ describe('NamespaceMetadataTransaction', () => {
                 UInt64.fromUint(1000),
                 new NamespaceId([2262289484, 3405110546]),
                 1,
-                Convert.uint8ToUtf8(new Uint8Array(10)),
+                new Uint8Array(10),
                 TestNetworkType,
             );
             expect(namespaceMetadataTransaction.size).to.be.equal(182);
@@ -103,7 +103,7 @@ describe('NamespaceMetadataTransaction', () => {
                 UInt64.fromUint(1000),
                 new NamespaceId([2262289484, 3405110546]),
                 1,
-                Convert.uint8ToUtf8(new Uint8Array(10)),
+                new Uint8Array(10),
                 TestNetworkType,
             );
             expect(namespaceMetadataTransaction.size).to.be.equal(182);
@@ -119,7 +119,7 @@ describe('NamespaceMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new NamespaceId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         ).setMaxFee(2);
         expect(namespaceMetadataTransaction.maxFee.compact()).to.be.equal(364);
@@ -135,7 +135,7 @@ describe('NamespaceMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new NamespaceId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
 
@@ -155,7 +155,7 @@ describe('NamespaceMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new NamespaceId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
         const resolved = namespaceMetadataTransaction.resolveAliases();
@@ -171,7 +171,7 @@ describe('NamespaceMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new NamespaceId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
         let canNotify = tx.shouldNotifyAccount(account.address);
@@ -193,7 +193,7 @@ describe('NamespaceMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new NamespaceId([2262289484, 3405110546]),
             1,
-            Convert.uint8ToUtf8(new Uint8Array(10)),
+            new Uint8Array(10),
             TestNetworkType,
         );
         let canNotify = tx.shouldNotifyAccount(alias);

--- a/test/model/transaction/NamespaceMetadataTransaction.spec.ts
+++ b/test/model/transaction/NamespaceMetadataTransaction.spec.ts
@@ -25,11 +25,14 @@ import { Deadline, NamespaceMetadataTransaction, TransactionType } from '../../.
 import { TestingAccount, TestNetworkType } from '../../conf/conf.spec';
 
 describe('NamespaceMetadataTransaction', () => {
-    let account: Account;
+    let account: Account, emptyValue: Uint8Array;
     const generationHash = '57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6';
     const epochAdjustment = 1573430400;
     before(() => {
         account = TestingAccount;
+    });
+    beforeEach(() => {
+        emptyValue = new Uint8Array(10);
     });
 
     it('should default maxFee field be set to 0', () => {
@@ -39,7 +42,7 @@ describe('NamespaceMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new NamespaceId([2262289484, 3405110546]),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
         );
 
@@ -54,7 +57,7 @@ describe('NamespaceMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new NamespaceId([2262289484, 3405110546]),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
             new UInt64([1, 0]),
         );
@@ -70,7 +73,7 @@ describe('NamespaceMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new NamespaceId([2262289484, 3405110546]),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
         );
 
@@ -89,7 +92,7 @@ describe('NamespaceMetadataTransaction', () => {
                 UInt64.fromUint(1000),
                 new NamespaceId([2262289484, 3405110546]),
                 1,
-                new Uint8Array(10),
+                emptyValue,
                 TestNetworkType,
             );
             expect(namespaceMetadataTransaction.size).to.be.equal(182);
@@ -103,7 +106,7 @@ describe('NamespaceMetadataTransaction', () => {
                 UInt64.fromUint(1000),
                 new NamespaceId([2262289484, 3405110546]),
                 1,
-                new Uint8Array(10),
+                emptyValue,
                 TestNetworkType,
             );
             expect(namespaceMetadataTransaction.size).to.be.equal(182);
@@ -119,7 +122,7 @@ describe('NamespaceMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new NamespaceId([2262289484, 3405110546]),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
         ).setMaxFee(2);
         expect(namespaceMetadataTransaction.maxFee.compact()).to.be.equal(364);
@@ -135,7 +138,7 @@ describe('NamespaceMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new NamespaceId([2262289484, 3405110546]),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
         );
 
@@ -155,7 +158,7 @@ describe('NamespaceMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new NamespaceId([2262289484, 3405110546]),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
         );
         const resolved = namespaceMetadataTransaction.resolveAliases();
@@ -171,7 +174,7 @@ describe('NamespaceMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new NamespaceId([2262289484, 3405110546]),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
         );
         let canNotify = tx.shouldNotifyAccount(account.address);
@@ -193,7 +196,7 @@ describe('NamespaceMetadataTransaction', () => {
             UInt64.fromUint(1000),
             new NamespaceId([2262289484, 3405110546]),
             1,
-            new Uint8Array(10),
+            emptyValue,
             TestNetworkType,
         );
         let canNotify = tx.shouldNotifyAccount(alias);

--- a/test/service/MetadataTransactionservice.spec.ts
+++ b/test/service/MetadataTransactionservice.spec.ts
@@ -124,7 +124,7 @@ describe('MetadataTransactionService', () => {
             .subscribe((transaction: AccountMetadataTransaction) => {
                 expect(transaction.type).to.be.equal(TransactionType.ACCOUNT_METADATA);
                 expect(transaction.scopedMetadataKey.toHex()).to.be.equal(key.toHex());
-                expect(Convert.utf8ToHex(transaction.value)).to.be.equal(
+                expect(Convert.uint8ToHex(transaction.value)).to.be.equal(
                     Convert.xor(Convert.utf8ToUint8(value), Convert.utf8ToUint8(value + deltaValue)),
                 );
                 expect(transaction.valueSizeDelta).to.be.equal(deltaValue.length);

--- a/test/service/MetadataTransactionservice.spec.ts
+++ b/test/service/MetadataTransactionservice.spec.ts
@@ -148,7 +148,7 @@ describe('MetadataTransactionService', () => {
             .subscribe((transaction: MosaicMetadataTransaction) => {
                 expect(transaction.type).to.be.equal(TransactionType.MOSAIC_METADATA);
                 expect(transaction.scopedMetadataKey.toHex()).to.be.equal(key.toHex());
-                expect(Convert.utf8ToHex(transaction.value)).to.be.equal(
+                expect(Convert.uint8ToHex(transaction.value)).to.be.equal(
                     Convert.xor(Convert.utf8ToUint8(value), Convert.utf8ToUint8(value + deltaValue)),
                 );
                 expect(transaction.targetMosaicId.toHex()).to.be.equal(targetIdHex);
@@ -173,7 +173,7 @@ describe('MetadataTransactionService', () => {
             .subscribe((transaction: NamespaceMetadataTransaction) => {
                 expect(transaction.type).to.be.equal(TransactionType.NAMESPACE_METADATA);
                 expect(transaction.scopedMetadataKey.toHex()).to.be.equal(key.toHex());
-                expect(Convert.utf8ToHex(transaction.value)).to.be.equal(
+                expect(Convert.uint8ToHex(transaction.value)).to.be.equal(
                     Convert.xor(Convert.utf8ToUint8(value), Convert.utf8ToUint8(value + deltaValue)),
                 );
                 expect(transaction.targetNamespaceId.toHex()).to.be.equal(targetIdHex);


### PR DESCRIPTION
fixes #834 

### What was the issue?
from #834 
> There is a problem when we want to replace the non-ascii text value in metadata with ascii one. In such a case we receive the error:
Failure_Metadata_Value_Size_Delta_Mismatch

### What's the fix?
We noticed that `value` field in the Metadata Transactions(`AccountMetadataTransaction`, `NamespaceMetadataTransaction`, `MosaicMetadataTransaction`) has the type `string`.
This was the root cause of the issue, since the `value` field was meant to be a difference between the previous and the new value in _bytes_, converting the difference to first `string` and then to `byte[]` was resulting in loss of bytes and therefore sending wrong information to the `catapult-rest`.

In order to fix this, we:
* Removed the `rstr2utf8` method which was used during the conversion, fixing _insert_ part of the problem.
* Changed the `value` type from `string` to `Uint8Array`
* Added test cases for the non-ascii utf8 text <-> byte array conversion.