### PR TITLE
fix: metadata value ser/deser is fixed

### DIFF
--- a/src/core/crypto/Utilities.ts
+++ b/src/core/crypto/Utilities.ts
@@ -15,7 +15,6 @@
  */
 
 import * as CryptoJS from 'crypto-js';
-import { WordArray } from 'crypto-js';
 import * as hkdf from 'futoin-hkdf';
 import { sha512 } from 'js-sha512';
 import { RawArray as array } from '../format';
@@ -34,7 +33,7 @@ export const Half_Hash_Size = Hash_Size / 2;
  *
  * @return {WordArray}
  */
-export const ua2words = (ua, uaLength): WordArray => {
+export const ua2words = (ua, uaLength): any => {
     const temp: number[] = [];
     for (let i = 0; i < uaLength; i += 4) {
         const x = ua[i] * 0x1000000 + (ua[i + 1] || 0) * 0x10000 + (ua[i + 2] || 0) * 0x100 + (ua[i + 3] || 0);

--- a/src/infrastructure/transaction/CreateTransactionFromDTO.ts
+++ b/src/infrastructure/transaction/CreateTransactionFromDTO.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { Convert } from '../..';
 import { UnresolvedMapping } from '../../core/utils';
 import { MessageFactory, MosaicSupplyRevocationTransaction, UInt64 } from '../../model';
 import { Address, PublicAccount } from '../../model/account';
@@ -392,7 +393,7 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
                 extractRecipient(transactionDTO.targetAddress),
                 UInt64.fromHex(transactionDTO.scopedMetadataKey),
                 transactionDTO.valueSizeDelta,
-                transactionDTO.value,
+                Convert.hexToUint8(transactionDTO.value),
                 signature,
                 signer,
                 transactionInfo,
@@ -407,7 +408,7 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
                 UInt64.fromHex(transactionDTO.scopedMetadataKey),
                 UnresolvedMapping.toUnresolvedMosaic(transactionDTO.targetMosaicId),
                 transactionDTO.valueSizeDelta,
-                transactionDTO.value,
+                Convert.hexToUint8(transactionDTO.value),
                 signature,
                 signer,
                 transactionInfo,
@@ -422,7 +423,7 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
                 UInt64.fromHex(transactionDTO.scopedMetadataKey),
                 NamespaceId.createFromEncoded(transactionDTO.targetNamespaceId),
                 transactionDTO.valueSizeDelta,
-                transactionDTO.value,
+                Convert.hexToUint8(transactionDTO.value),
                 signature,
                 signer,
                 transactionInfo,

--- a/src/infrastructure/transaction/SerializeTransactionToJSON.ts
+++ b/src/infrastructure/transaction/SerializeTransactionToJSON.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { Convert } from '../..';
 import {
     AccountAddressRestrictionTransaction,
     AccountKeyLinkTransaction,
@@ -245,7 +246,7 @@ export const SerializeTransactionToJSON = (transaction: Transaction): any => {
             scopedMetadataKey: accountMetadataTx.scopedMetadataKey.toHex(),
             valueSizeDelta: accountMetadataTx.valueSizeDelta,
             valueSize: accountMetadataTx.value.length,
-            value: accountMetadataTx.value,
+            value: Convert.uint8ToHex(accountMetadataTx.value),
         };
     } else if (transaction.type === TransactionType.MOSAIC_METADATA) {
         const mosaicMetadataTx = transaction as MosaicMetadataTransaction;
@@ -255,7 +256,7 @@ export const SerializeTransactionToJSON = (transaction: Transaction): any => {
             valueSizeDelta: mosaicMetadataTx.valueSizeDelta,
             targetMosaicId: mosaicMetadataTx.targetMosaicId.id.toHex(),
             valueSize: mosaicMetadataTx.value.length,
-            value: mosaicMetadataTx.value,
+            value: Convert.uint8ToHex(mosaicMetadataTx.value),
         };
     } else if (transaction.type === TransactionType.NAMESPACE_METADATA) {
         const namespaceMetaTx = transaction as NamespaceMetadataTransaction;
@@ -265,7 +266,7 @@ export const SerializeTransactionToJSON = (transaction: Transaction): any => {
             valueSizeDelta: namespaceMetaTx.valueSizeDelta,
             targetNamespaceId: namespaceMetaTx.targetNamespaceId.id.toHex(),
             valueSize: namespaceMetaTx.value.length,
-            value: namespaceMetaTx.value,
+            value: Convert.uint8ToHex(namespaceMetaTx.value),
         };
     } else if (transaction.type === TransactionType.VRF_KEY_LINK) {
         const vrfKeyLinkTx = transaction as VrfKeyLinkTransaction;

--- a/test/infrastructure/transaction/ValidateTransaction.ts
+++ b/test/infrastructure/transaction/ValidateTransaction.ts
@@ -16,6 +16,7 @@
 
 import { deepEqual } from 'assert';
 import { expect } from 'chai';
+import { Convert } from '../../..';
 import { Address } from '../../../src/model/account/Address';
 import { MosaicId } from '../../../src/model/mosaic/MosaicId';
 import { NamespaceId } from '../../../src/model/namespace/NamespaceId';
@@ -50,6 +51,12 @@ const ValidateTransaction = {
             ValidateTransaction.validateMosaicSupplyRevocationTx(transaction, transactionDTO);
         } else if (transaction.type === TransactionType.MULTISIG_ACCOUNT_MODIFICATION) {
             ValidateTransaction.validateMultisigModificationTx(transaction, transactionDTO);
+        } else if (transaction.type === TransactionType.ACCOUNT_METADATA) {
+            ValidateTransaction.validateMetadataTx(transaction, transactionDTO);
+        } else if (transaction.type === TransactionType.MOSAIC_METADATA) {
+            ValidateTransaction.validateMosaicMetadataTx(transaction, transactionDTO);
+        } else if (transaction.type === TransactionType.NAMESPACE_METADATA) {
+            ValidateTransaction.validateNamespaceMetadataTx(transaction, transactionDTO);
         }
     },
     validateAggregateTx: (aggregateTransaction: any, aggregateTransactionDTO: any): void => {
@@ -121,6 +128,26 @@ const ValidateTransaction = {
     validateTransferTx: (transferTransaction: any, transferTransactionDTO: any): void => {
         deepEqual(transferTransaction.recipientAddress, Address.createFromEncoded(transferTransactionDTO.transaction.recipientAddress));
         expect(transferTransaction.message.payload).to.be.equal('test-message');
+    },
+    validateMetadataTx: (metadataTransaction: any, metadataTransactionDTO: any): void => {
+        expect(metadataTransaction.targetAddress.plain()).to.be.equal(metadataTransactionDTO.transaction.targetAddress);
+        expect(metadataTransaction.metadataType).to.be.equal(metadataTransactionDTO.transaction.metadataType);
+        deepEqual(metadataTransaction.scopedMetadataKey, UInt64.fromHex(metadataTransactionDTO.transaction.scopedMetadataKey));
+        expect(metadataTransaction.valueSizeDelta).to.be.equal(metadataTransactionDTO.transaction.valueSizeDelta);
+        deepEqual(metadataTransaction.value, Convert.hexToUint8(metadataTransactionDTO.transaction.value));
+    },
+    validateAccountMetadataTx: (accountMetadataTransaction: any, accountMetadataTransactionDTO: any): void => {
+        ValidateTransaction.validateMetadataTx(accountMetadataTransaction, accountMetadataTransactionDTO);
+    },
+    validateMosaicMetadataTx: (mosaicMetadataTransaction: any, mosaicMetadataTransactionDTO: any): void => {
+        ValidateTransaction.validateMetadataTx(mosaicMetadataTransaction, mosaicMetadataTransactionDTO);
+        expect(mosaicMetadataTransaction.targetMosaicId.toHex()).to.be.equal(mosaicMetadataTransactionDTO.transaction.targetMosaicId);
+    },
+    validateNamespaceMetadataTx: (namespaceMetadataTransaction: any, namespaceMetadataTransactionDTO: any): void => {
+        ValidateTransaction.validateMetadataTx(namespaceMetadataTransaction, namespaceMetadataTransactionDTO);
+        expect(namespaceMetadataTransaction.targetNamespaceId.toHex()).to.be.equal(
+            namespaceMetadataTransactionDTO.transaction.targetNamespaceId,
+        );
     },
 };
 


### PR DESCRIPTION
### What was the issue?
After the type of `Metadata.value` is changed from `string` to `byte array`,  we noticed that JSON serialization and deserialization started to fail.

### The fix
`byte array` is now being converted to `hex` value during serialization and converted back during deserialization.