### PR TITLE
prep for release v2.0.0, updated CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [1.0.4] - NEXY
+## [2.0.0] - 01-Mar-2022
 
 **Milestone**: Symbol Mainnet
 Package  | Version  | Link
 ---|---|---
-SDK Core| v1.0.4 | [symbol-sdk](https://www.npmjs.com/package/symbol-sdk)
+SDK Core| v2.0.0 | [symbol-sdk](https://www.npmjs.com/package/symbol-sdk)
 Catbuffer | v1.0.1 | [catbuffer-typescript](https://www.npmjs.com/package/catbuffer-typescript)
 Client Library | v1.0.3  | [symbol-openapi-typescript-fetch-client](https://www.npmjs.com/package/symbol-openapi-typescript-fetch-client)
 
+- **[BREAKING CHANGE]** The type of `value` field in `AccountMetadataTransaction`, `MosaicMetadataTransaction`, `NamespaceMetadataTransaction` classes is changed from `string` to `Uint8Array`.
+- fix: Fixed metadata value non-ascii utf8 encoding issue [#834](https://github.com/symbol/symbol-sdk-typescript-javascript/issues/834)
 - fix: Upgraded Node to 12.22.1.
 - fix: Upgraded typescript to 4.5.4.
 - fix: Upgraded RXJS to 7.4.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "symbol-sdk",
-    "version": "1.0.4",
+    "version": "2.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "symbol-sdk",
-            "version": "1.0.3",
+            "version": "2.0.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@js-joda/core": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "symbol-sdk",
-    "version": "1.0.4",
+    "version": "2.0.0",
     "description": "Reactive symbol sdk for typescript and javascript",
     "scripts": {
         "pretest": "npm run build",
@@ -74,7 +74,7 @@
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
         "assert": "^1.5.0",
-            "chai": "^4.2.0",
+        "chai": "^4.2.0",
         "coveralls": "^3.1.0",
         "create-ts-index": "^1.13.6",
         "eslint": "^8.0.1",


### PR DESCRIPTION
Since the change in the `MetadataTransaction.value` type is a breaking change and requires small code change in the clients, this release is prepared as a major release(v1.0.3 -> **v2.0.0**)
* prep for release v2.0.0
* updated CHANGELOG.md

## CHANGELOG:
## [2.0.0] - 01-Mar-2022

**Milestone**: Symbol Mainnet
Package  | Version  | Link
---|---|---
SDK Core| v2.0.0 | [symbol-sdk](https://www.npmjs.com/package/symbol-sdk)
Catbuffer | v1.0.1 | [catbuffer-typescript](https://www.npmjs.com/package/catbuffer-typescript)
Client Library | v1.0.3  | [symbol-openapi-typescript-fetch-client](https://www.npmjs.com/package/symbol-openapi-typescript-fetch-client)

- **[BREAKING CHANGE]** The type of `value` field in `AccountMetadataTransaction`, `MosaicMetadataTransaction`, `NamespaceMetadataTransaction` classes is changed from `string` to `Uint8Array`.
- fix: Fixed metadata value non-ascii utf8 encoding issue [#834](https://github.com/symbol/symbol-sdk-typescript-javascript/issues/834)
- fix: Upgraded Node to 12.22.1.
- fix: Upgraded typescript to 4.5.4.
- fix: Upgraded RXJS to 7.4.0.