### PR TITLE
Replace js-sha3 with @noble/hashes

### DIFF
--- a/e2e/infrastructure/SecretLockHttp.spec.ts
+++ b/e2e/infrastructure/SecretLockHttp.spec.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+import { sha3_256 } from '@noble/hashes/sha3';
+import { bytesToHex } from '@noble/hashes/utils';
 import { deepEqual } from 'assert';
 import { expect } from 'chai';
-import { sha3_256 } from 'js-sha3';
 import { firstValueFrom } from 'rxjs';
 import { take, toArray } from 'rxjs/operators';
 import { Crypto } from '../../src/core/crypto';
@@ -46,7 +47,7 @@ describe('SecretLockHttp', () => {
             networkType = helper.networkType;
             generationHash = helper.generationHash;
             secretLockRepository = helper.repositoryFactory.createSecretLockRepository();
-            secret = sha3_256.create().update(Crypto.randomBytes(20)).hex();
+            secret = bytesToHex(sha3_256(Crypto.randomBytes(20)));
         });
     });
 

--- a/e2e/infrastructure/TransactionHttp.spec.ts
+++ b/e2e/infrastructure/TransactionHttp.spec.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 import { ChronoUnit } from '@js-joda/core';
+import { sha3_256 } from '@noble/hashes/sha3';
+import { bytesToHex } from '@noble/hashes/utils';
 import { deepEqual } from 'assert';
 import { expect } from 'chai';
 import * as CryptoJS from 'crypto-js';
 import { sha256 } from 'js-sha256';
-import { sha3_256 } from 'js-sha3';
 import * as ripemd160 from 'ripemd160';
 import { firstValueFrom } from 'rxjs';
 import { take, toArray } from 'rxjs/operators';
@@ -1019,7 +1020,7 @@ describe('TransactionHttp', () => {
                 helper.createCurrency(10, false),
                 UInt64.fromUint(100),
                 LockHashAlgorithm.Op_Sha3_256,
-                sha3_256.create().update(Crypto.randomBytes(20)).hex(),
+                bytesToHex(sha3_256(Crypto.randomBytes(20))),
                 account2.address,
                 networkType,
                 helper.maxFee,
@@ -1041,7 +1042,7 @@ describe('TransactionHttp', () => {
                 helper.createCurrency(10, false),
                 UInt64.fromUint(100),
                 LockHashAlgorithm.Op_Sha3_256,
-                sha3_256.create().update(Crypto.randomBytes(20)).hex(),
+                bytesToHex(sha3_256(Crypto.randomBytes(20))),
                 account2.address,
                 networkType,
                 helper.maxFee,
@@ -1105,7 +1106,7 @@ describe('TransactionHttp', () => {
                 helper.createCurrency(10, false),
                 UInt64.fromUint(100),
                 LockHashAlgorithm.Op_Hash_256,
-                sha3_256.create().update(Crypto.randomBytes(20)).hex(),
+                bytesToHex(sha3_256(Crypto.randomBytes(20))),
                 account2.address,
                 networkType,
                 helper.maxFee,
@@ -1120,7 +1121,7 @@ describe('TransactionHttp', () => {
                 helper.createCurrency(10, false),
                 UInt64.fromUint(100),
                 LockHashAlgorithm.Op_Hash_256,
-                sha3_256.create().update(Crypto.randomBytes(20)).hex(),
+                bytesToHex(sha3_256(Crypto.randomBytes(20))),
                 account2.address,
                 networkType,
                 helper.maxFee,
@@ -1178,7 +1179,7 @@ describe('TransactionHttp', () => {
     describe('SecretProofTransaction - HashType: Op_Sha3_256', () => {
         it('aggregate', () => {
             const secretSeed = Crypto.randomBytes(20);
-            const secret = sha3_256.create().update(secretSeed).hex();
+            const secret = bytesToHex(sha3_256(secretSeed));
             const proof = convert.uint8ToHex(secretSeed);
             const secretLockTransaction = SecretLockTransaction.create(
                 Deadline.create(helper.epochAdjustment),

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@js-joda/core": "^3.2.0",
+                "@noble/hashes": "^1.0.0",
                 "catbuffer-typescript": "^1.0.1",
                 "crypto-js": "^4.0.0",
                 "futoin-hkdf": "^1.3.2",
                 "js-sha256": "^0.9.0",
-                "js-sha3": "^0.8.0",
                 "js-sha512": "^0.8.0",
                 "long": "^4.0.0",
                 "merkletreejs": "^0.2.9",
@@ -470,6 +470,11 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-3.2.0.tgz",
             "integrity": "sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg=="
+        },
+        "node_modules/@noble/hashes": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.0.0.tgz",
+            "integrity": "sha512-DZVbtY62kc3kkBtMHqwCOfXrT/hnoORy5BJ4+HU1IR59X0KWAOqsfzQPcUl/lQLlG7qXbe/fZ3r/emxtAl+sqg=="
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.3",
@@ -4006,7 +4011,8 @@
         "node_modules/js-sha3": {
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-            "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+            "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+            "dev": true
         },
         "node_modules/js-sha512": {
             "version": "0.8.0",
@@ -7235,6 +7241,11 @@
             "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-3.2.0.tgz",
             "integrity": "sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg=="
         },
+        "@noble/hashes": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.0.0.tgz",
+            "integrity": "sha512-DZVbtY62kc3kkBtMHqwCOfXrT/hnoORy5BJ4+HU1IR59X0KWAOqsfzQPcUl/lQLlG7qXbe/fZ3r/emxtAl+sqg=="
+        },
         "@nodelib/fs.scandir": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -9941,7 +9952,8 @@
         "js-sha3": {
             "version": "0.8.0",
             "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-            "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+            "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
+            "dev": true
         },
         "js-sha512": {
             "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -97,11 +97,11 @@
     },
     "dependencies": {
         "@js-joda/core": "^3.2.0",
+        "@noble/hashes": "^1.0.0",
         "catbuffer-typescript": "^1.0.1",
         "crypto-js": "^4.0.0",
         "futoin-hkdf": "^1.3.2",
         "js-sha256": "^0.9.0",
-        "js-sha3": "^0.8.0",
         "js-sha512": "^0.8.0",
         "long": "^4.0.0",
         "merkletreejs": "^0.2.9",

--- a/src/core/crypto/MerkleHashBuilder.ts
+++ b/src/core/crypto/MerkleHashBuilder.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { SHA3Hasher } from './SHA3Hasher';
+import { HashLength, SHA3Hasher } from './SHA3Hasher';
 
 export class MerkleHashBuilder {
     /**
@@ -33,7 +33,7 @@ export class MerkleHashBuilder {
          *
          * @var {number}
          */
-        public readonly length: number,
+        public readonly length: HashLength,
     ) {}
 
     /**

--- a/src/core/crypto/SHA3Hasher.ts
+++ b/src/core/crypto/SHA3Hasher.ts
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 
-import { sha3_256, sha3_512 } from 'js-sha3';
+import { Keccak, sha3_256, sha3_512 } from '@noble/hashes/sha3';
+import { Hash } from '@noble/hashes/utils';
 import { Convert as convert, RawArray as array } from '../format';
+
+export type HashLength = 32 | 64;
 
 export class SHA3Hasher {
     /**
@@ -24,9 +27,9 @@ export class SHA3Hasher {
      * @param {Uint8Array} data The data to hash.
      * @param {number} length The hash length in bytes.
      */
-    public static func = (dest: Uint8Array, data: Uint8Array, length: number): void => {
+    public static func = (dest: Uint8Array, data: Uint8Array, length: HashLength): void => {
         const hasher = SHA3Hasher.getHasher(length);
-        const hash = hasher.arrayBuffer(data);
+        const hash = hasher(data).buffer;
         array.copy(dest, array.uint8View(hash));
     };
 
@@ -35,8 +38,8 @@ export class SHA3Hasher {
      * @param {number} length The hash length in bytes.
      * @returns {object} The hasher.
      */
-    public static createHasher = (length = 64): any => {
-        let hash;
+    public static createHasher = (length: HashLength = 64) => {
+        let hash: Hash<Keccak>;
         return {
             reset: (): void => {
                 hash = SHA3Hasher.getHasher(length).create();
@@ -51,7 +54,7 @@ export class SHA3Hasher {
                 }
             },
             finalize: (result: any): void => {
-                array.copy(result, array.uint8View(hash.arrayBuffer()));
+                array.copy(result, array.uint8View(hash.digest().buffer));
             },
         };
     };
@@ -61,7 +64,7 @@ export class SHA3Hasher {
      * @param {numeric} length The hash length in bytes.
      * @returns {object} The hasher.
      */
-    public static getHasher = (length = 64): any => {
+    public static getHasher = (length: HashLength = 64) => {
         return {
             32: sha3_256,
             64: sha3_512,

--- a/src/core/format/IdGenerator.ts
+++ b/src/core/format/IdGenerator.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { sha3_256 } from 'js-sha3';
+import { SHA3Hasher } from '../crypto';
 import * as utilities from './Utilities';
 
 export class IdGenerator {
@@ -23,11 +23,11 @@ export class IdGenerator {
      * @param {object} ownerAddress The address.
      * @returns {module:coders/uint64~uint64} The mosaic id.
      */
-    public static generateMosaicId = (nonce: any, ownerAddress: any): number[] => {
-        const hash = sha3_256.create();
-        hash.update(nonce);
-        hash.update(ownerAddress);
-        const result = new Uint32Array(hash.arrayBuffer());
+    public static generateMosaicId = (nonce: number[] | Uint8Array, ownerAddress: number[] | Uint8Array): number[] => {
+        const hash = SHA3Hasher.getHasher(32).create();
+        hash.update(new Uint8Array(nonce));
+        hash.update(new Uint8Array(ownerAddress));
+        const result = new Uint32Array(hash.digest().buffer);
         return [result[0], result[1] & 0x7fffffff];
     };
 

--- a/src/core/format/KeyGenerator.ts
+++ b/src/core/format/KeyGenerator.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { sha3_256 } from 'js-sha3';
 import { UInt64 } from '../../model/UInt64';
+import { SHA3Hasher } from '../crypto';
 
 export class KeyGenerator {
     /**
@@ -27,7 +27,7 @@ export class KeyGenerator {
         if (input.length === 0) {
             throw Error(`Input must not be empty`);
         }
-        const buf = sha3_256.arrayBuffer(input);
+        const buf = SHA3Hasher.getHasher(32)(input).buffer;
         const result = new Uint32Array(buf);
         return new UInt64([result[0], (result[1] | 0x80000000) >>> 0]);
     }

--- a/src/core/format/RawAddress.ts
+++ b/src/core/format/RawAddress.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { sha3_256 } from 'js-sha3';
 import * as ripemd160 from 'ripemd160';
 import { NetworkType } from '../../model/network/NetworkType';
+import { SHA3Hasher } from '../crypto';
 import { Base32 } from './Base32';
 import { Convert } from './Convert';
 import { RawArray } from './RawArray';
@@ -80,7 +80,7 @@ export class RawAddress {
      */
     public static publicKeyToAddress = (publicKey: Uint8Array, networkType: NetworkType): Uint8Array => {
         // step 1: sha3 hash of the public key
-        const publicKeyHash = sha3_256.arrayBuffer(publicKey);
+        const publicKeyHash = SHA3Hasher.getHasher(32)(publicKey).buffer;
 
         // step 2: ripemd160 hash of (1)
         const ripemdHash = new ripemd160().update(Buffer.from(publicKeyHash)).digest();
@@ -91,7 +91,7 @@ export class RawAddress {
         RawArray.copy(decodedAddress, ripemdHash, RawAddress.constants.sizes.ripemd160, 1);
 
         // step 4: concatenate (3) and the checksum of (3)
-        const hash = sha3_256.arrayBuffer(decodedAddress.subarray(0, RawAddress.constants.sizes.ripemd160 + 1));
+        const hash = SHA3Hasher.getHasher(32)(decodedAddress.subarray(0, RawAddress.constants.sizes.ripemd160 + 1)).buffer;
 
         RawArray.copy(
             decodedAddress,
@@ -112,11 +112,11 @@ export class RawAddress {
         if (RawAddress.constants.sizes.addressDecoded !== decoded.length) {
             return false;
         }
-        const hash = sha3_256.create();
+        const hash = SHA3Hasher.getHasher(32).create();
         const checksumBegin = RawAddress.constants.sizes.addressDecoded - RawAddress.constants.sizes.checksum;
         hash.update(decoded.subarray(0, checksumBegin));
         const checksum = new Uint8Array(RawAddress.constants.sizes.checksum);
-        RawArray.copy(checksum, RawArray.uint8View(hash.arrayBuffer()), RawAddress.constants.sizes.checksum);
+        RawArray.copy(checksum, RawArray.uint8View(hash.digest().buffer), RawAddress.constants.sizes.checksum);
         return RawArray.deepEqual(checksum, decoded.subarray(checksumBegin));
     };
 }

--- a/src/core/format/Utilities.ts
+++ b/src/core/format/Utilities.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { sha3_256 } from 'js-sha3';
+import { SHA3Hasher } from '../crypto';
 
 export const createBuilder = (): any => {
     const map = {};
@@ -126,10 +126,10 @@ export const split = (name: string, processor: any): any => {
 };
 
 export const generateNamespaceId = (parentId: number[], name: string): number[] => {
-    const hash = sha3_256.create();
-    hash.update(Uint32Array.from(parentId).buffer as any);
+    const hash = SHA3Hasher.getHasher(32).create();
+    hash.update(new Uint8Array(Uint32Array.from(parentId).buffer));
     hash.update(name);
-    const result = new Uint32Array(hash.arrayBuffer());
+    const result = new Uint32Array(hash.digest().buffer);
     // right zero-filling required to keep unsigned number representation
     return [result[0], (result[1] | 0x80000000) >>> 0];
 };

--- a/src/core/utils/LockHashUtils.ts
+++ b/src/core/utils/LockHashUtils.ts
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
+import { bytesToHex } from '@noble/hashes/utils';
 import { sha256 } from 'js-sha256';
-import { sha3_256 } from 'js-sha3';
 import * as ripemd160 from 'ripemd160';
 import { LockHashAlgorithm } from '../../model/lock/LockHashAlgorithm';
+import { SHA3Hasher } from '../crypto';
 
 /**
  * Hash utilities for SecretLock hashing
@@ -29,7 +30,7 @@ export class LockHashUtils {
      * @returns {string} Hash in hexidecimal format
      */
     public static Op_Sha3_256(input: Uint8Array): string {
-        return sha3_256.create().update(input).hex().toUpperCase();
+        return bytesToHex(SHA3Hasher.getHasher(32)(input)).toUpperCase();
     }
 
     /**

--- a/src/model/receipt/ResolutionStatement.ts
+++ b/src/model/receipt/ResolutionStatement.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { bytesToHex } from '@noble/hashes/utils';
 import {
     AddressResolutionEntryBuilder,
     AddressResolutionStatementBuilder,
@@ -23,7 +24,7 @@ import {
     UnresolvedAddressDto,
     UnresolvedMosaicIdDto,
 } from 'catbuffer-typescript';
-import { sha3_256 } from 'js-sha3';
+import { SHA3Hasher } from '../../core';
 import { UnresolvedMapping } from '../../core/utils/UnresolvedMapping';
 import { Address } from '../account/Address';
 import { UnresolvedAddress } from '../account/UnresolvedAddress';
@@ -114,9 +115,9 @@ export class ResolutionStatement<U extends UnresolvedAddress | UnresolvedMosaicI
                               ),
                       ),
                   );
-        const hasher = sha3_256.create();
+        const hasher = SHA3Hasher.getHasher(32).create();
         hasher.update(builder.serialize());
-        return hasher.hex().toUpperCase();
+        return bytesToHex(hasher.digest()).toUpperCase();
     }
 
     /**

--- a/src/model/receipt/TransactionStatement.ts
+++ b/src/model/receipt/TransactionStatement.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
+import { bytesToHex } from '@noble/hashes/utils';
 import { GeneratorUtils } from 'catbuffer-typescript';
-import { sha3_256 } from 'js-sha3';
+import { SHA3Hasher } from '../../core';
 import { UInt64 } from '../UInt64';
 import { Receipt } from './Receipt';
 import { ReceiptSource } from './ReceiptSource';
@@ -55,7 +56,7 @@ export class TransactionStatement {
      * @return {string} receipt hash in hex
      */
     public generateHash(): string {
-        const hasher = sha3_256.create();
+        const hasher = SHA3Hasher.getHasher(32).create();
         hasher.update(GeneratorUtils.uintToBuffer(ReceiptVersion.TRANSACTION_STATEMENT, 2));
         hasher.update(GeneratorUtils.uintToBuffer(ReceiptType.Transaction_Group, 2));
         hasher.update(this.source.serialize());
@@ -67,6 +68,6 @@ export class TransactionStatement {
         });
 
         hasher.update(receiptBytes);
-        return hasher.hex().toUpperCase();
+        return bytesToHex(hasher.digest()).toUpperCase();
     }
 }

--- a/src/model/state/MerkleTreeParser.ts
+++ b/src/model/state/MerkleTreeParser.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { bytesToHex } from '@noble/hashes/utils';
 import { SHA3Hasher } from '../../core/crypto';
 import { Convert } from '../../core/format';
 import { MerkleTreeBranch } from './MerkleTreeBranch';
@@ -192,10 +193,7 @@ export default class MerkleTreeParser {
         links.forEach((link) => {
             branchLinks[parseInt(`0x${link.bit}`, 16)] = link.link;
         });
-        return SHA3Hasher.getHasher(32)
-            .update(Convert.hexToUint8(encodedPath + branchLinks.join('')))
-            .hex()
-            .toUpperCase();
+        return bytesToHex(SHA3Hasher.getHasher(32)(Convert.hexToUint8(encodedPath + branchLinks.join('')))).toUpperCase();
     }
 
     /**
@@ -205,9 +203,6 @@ export default class MerkleTreeParser {
      * @returns {string} leaf hash (Hash(encodedPath + leaf value))
      */
     getLeafHash(encodedPath: string, leafValue): string {
-        return SHA3Hasher.getHasher(32)
-            .update(Convert.hexToUint8(encodedPath + leafValue))
-            .hex()
-            .toUpperCase();
+        return bytesToHex(SHA3Hasher.getHasher(32)(Convert.hexToUint8(encodedPath + leafValue))).toUpperCase();
     }
 }

--- a/src/service/StateProofService.ts
+++ b/src/service/StateProofService.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { sha3_256 } from 'js-sha3';
+import { bytesToHex } from '@noble/hashes/utils';
 import { Observable } from 'rxjs';
 import { map, mergeMap, toArray } from 'rxjs/operators';
+import { SHA3Hasher } from '../core';
 import { Convert } from '../core/format';
 import { BlockRepository, RepositoryFactory } from '../infrastructure';
 import {
@@ -245,7 +246,7 @@ export class StateProofService {
 
     private toProof(serialized: Uint8Array, merkle: MerkleStateInfo): StateMerkleProof {
         const hash = Convert.uint8ToHex(serialized);
-        const stateHash = sha3_256.create().update(Convert.hexToUint8(hash)).hex().toUpperCase();
+        const stateHash = bytesToHex(SHA3Hasher.getHasher(32)(Convert.hexToUint8(hash))).toUpperCase();
         const valid = stateHash === merkle.tree.leaf?.value;
         return new StateMerkleProof(stateHash, merkle.tree, this.getRootHash(merkle.tree), merkle.tree.leaf?.value, valid);
     }

--- a/test/core/format/IdGenerator.spec.ts
+++ b/test/core/format/IdGenerator.spec.ts
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { sha3_256 } from '@noble/hashes/sha3';
 import { expect } from 'chai';
-import { sha3_256 } from 'js-sha3';
 import { IdGenerator as idGenerator } from '../../../src/core/format';
 import { Address } from '../../../src/model/account/Address';
 import { MosaicId } from '../../../src/model/mosaic/MosaicId';
@@ -110,9 +110,9 @@ const mosaicTestVector = [
 describe('id generator', () => {
     function generateNamespaceId(parentId, name): number[] {
         const hash = sha3_256.create();
-        hash.update(Uint32Array.from(parentId).buffer);
+        hash.update(new Uint8Array(Uint32Array.from(parentId).buffer));
         hash.update(name);
-        const result = new Uint32Array(hash.arrayBuffer());
+        const result = new Uint32Array(hash.digest().buffer);
         // right zero-filling required to keep unsigned number representation
         return [result[0], (result[1] | 0x80000000) >>> 0];
     }

--- a/test/core/utils/Hashes.spec.ts
+++ b/test/core/utils/Hashes.spec.ts
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { sha3_256 } from '@noble/hashes/sha3';
+import { bytesToHex } from '@noble/hashes/utils';
 import { expect } from 'chai';
 import { sha256 } from 'js-sha256';
-import { sha3_256 } from 'js-sha3';
 import * as ripemd160 from 'ripemd160';
 import { Crypto } from '../../../src/core/crypto';
 import { Convert } from '../../../src/core/format/Convert';
@@ -25,7 +26,7 @@ import { LockHashAlgorithm } from '../../../src/model/lock/LockHashAlgorithm';
 describe('Hashes', () => {
     it('Op_Sha3_256', () => {
         const secretSeed = Crypto.randomBytes(20);
-        const expected = sha3_256.create().update(secretSeed).hex();
+        const expected = bytesToHex(sha3_256(secretSeed));
         const hash = LockHashUtils.Op_Sha3_256(secretSeed);
         expect(expected.toUpperCase()).to.be.equal(hash);
     });
@@ -51,7 +52,7 @@ describe('Hashes', () => {
     it('Hash', () => {
         const secretSeed = Crypto.randomBytes(20);
 
-        const expectedSHA3 = sha3_256.create().update(secretSeed).hex();
+        const expectedSHA3 = bytesToHex(sha3_256(secretSeed));
         const hashSHA3 = LockHashUtils.Hash(LockHashAlgorithm.Op_Sha3_256, secretSeed);
         expect(expectedSHA3.toUpperCase()).to.be.equal(hashSHA3);
 

--- a/test/core/utils/TransactionMapping.spec.ts
+++ b/test/core/utils/TransactionMapping.spec.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+import { sha3_256 } from '@noble/hashes/sha3';
+import { bytesToHex } from '@noble/hashes/utils';
 import { deepEqual } from 'assert';
 import { expect } from 'chai';
-import { sha3_256 } from 'js-sha3';
 import { Convert } from '../../../src/core/format';
 import { DtoMapping, TransactionMapping } from '../../../src/core/utils';
 import {
@@ -383,7 +384,7 @@ describe('TransactionMapping - createFromPayload', () => {
             NetworkCurrencyLocal.createAbsolute(10),
             UInt64.fromUint(100),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(Convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(Convert.hexToUint8(proof))),
             recipientAddress,
             TestNetworkType,
         );
@@ -408,7 +409,7 @@ describe('TransactionMapping - createFromPayload', () => {
         const secretProofTransaction = SecretProofTransaction.create(
             Deadline.createFromDTO('555'),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(Convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(Convert.hexToUint8(proof))),
             account.address,
             proof,
             TestNetworkType,
@@ -556,7 +557,7 @@ describe('TransactionMapping - createFromPayload', () => {
         const secretProofTransaction = SecretProofTransaction.create(
             Deadline.createFromDTO('555'),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(Convert.hexToUint8('B778A39A3663719DFC5E48C9D78431B1E45C2AF9DF538782BF199C189DABEAC7')).hex(),
+            bytesToHex(sha3_256(Convert.hexToUint8('B778A39A3663719DFC5E48C9D78431B1E45C2AF9DF538782BF199C189DABEAC7'))),
             account.address,
             'B778A39A3663719DFC5E48C9D78431B1E45C2AF9DF538782BF199C189DABEAC7',
             TestNetworkType,
@@ -1247,7 +1248,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
             NetworkCurrencyLocal.createAbsolute(10),
             UInt64.fromUint(100),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(Convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(Convert.hexToUint8(proof))),
             recipientAddress,
             TestNetworkType,
         );
@@ -1270,7 +1271,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
             NetworkCurrencyLocal.createAbsolute(10),
             UInt64.fromUint(100),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(Convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(Convert.hexToUint8(proof))),
             recipientAddress,
             TestNetworkType,
         );
@@ -1294,7 +1295,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
             new Mosaic(new MosaicId([1, 1]), UInt64.fromUint(10)),
             UInt64.fromUint(100),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(Convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(Convert.hexToUint8(proof))),
             recipientAddress,
             TestNetworkType,
         );
@@ -1315,7 +1316,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
         const secretProofTransaction = SecretProofTransaction.create(
             Deadline.createFromDTO('555'),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(Convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(Convert.hexToUint8(proof))),
             account.address,
             proof,
             TestNetworkType,
@@ -1329,7 +1330,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
 
         expect(transaction.type).to.be.equal(TransactionType.SECRET_PROOF);
         expect(transaction.hashAlgorithm).to.be.equal(LockHashAlgorithm.Op_Sha3_256);
-        expect(transaction.secret).to.be.equal(sha3_256.create().update(Convert.hexToUint8(proof)).hex());
+        expect(transaction.secret).to.be.equal(bytesToHex(sha3_256(Convert.hexToUint8(proof))));
         deepEqual(transaction.recipientAddress, account.address);
         expect(transaction.proof).to.be.equal(proof);
     });
@@ -1340,7 +1341,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
         const secretProofTransaction = SecretProofTransaction.create(
             Deadline.createFromDTO('555'),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(Convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(Convert.hexToUint8(proof))),
             recipientAddress,
             proof,
             TestNetworkType,
@@ -1354,7 +1355,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
 
         expect(transaction.type).to.be.equal(TransactionType.SECRET_PROOF);
         expect(transaction.hashAlgorithm).to.be.equal(LockHashAlgorithm.Op_Sha3_256);
-        expect(transaction.secret).to.be.equal(sha3_256.create().update(Convert.hexToUint8(proof)).hex());
+        expect(transaction.secret).to.be.equal(bytesToHex(sha3_256(Convert.hexToUint8(proof))));
         expect(transaction.proof).to.be.equal(proof);
         expect((transaction.recipientAddress as NamespaceId).id.toHex()).to.be.equal(recipientAddress.toHex());
     });

--- a/test/core/utils/TransactionMappingWithSignatures.spec.ts
+++ b/test/core/utils/TransactionMappingWithSignatures.spec.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+import { sha3_256 } from '@noble/hashes/sha3';
+import { bytesToHex } from '@noble/hashes/utils';
 import { deepEqual } from 'assert';
 import { expect } from 'chai';
-import { sha3_256 } from 'js-sha3';
 import { Crypto } from '../../../src/core/crypto';
 import { Convert } from '../../../src/core/format';
 import { TransactionMapping } from '../../../src/core/utils';
@@ -371,7 +372,7 @@ describe('TransactionMapping - createFromPayload with optional sigature and sign
             NetworkCurrencyLocal.createAbsolute(10),
             UInt64.fromUint(100),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(Convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(Convert.hexToUint8(proof))),
             recipientAddress,
             NetworkType.TEST_NET,
             undefined,
@@ -404,7 +405,7 @@ describe('TransactionMapping - createFromPayload with optional sigature and sign
         const secretProofTransaction = SecretProofTransaction.create(
             Deadline.create(epochAdjustment),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(Convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(Convert.hexToUint8(proof))),
             account.address,
             proof,
             NetworkType.TEST_NET,
@@ -567,7 +568,7 @@ describe('TransactionMapping - createFromPayload with optional sigature and sign
         const secretProofTransaction = SecretProofTransaction.create(
             Deadline.create(epochAdjustment),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(Convert.hexToUint8('B778A39A3663719DFC5E48C9D78431B1E45C2AF9DF538782BF199C189DABEAC7')).hex(),
+            bytesToHex(sha3_256(Convert.hexToUint8('B778A39A3663719DFC5E48C9D78431B1E45C2AF9DF538782BF199C189DABEAC7'))),
             account.address,
             'B778A39A3663719DFC5E48C9D78431B1E45C2AF9DF538782BF199C189DABEAC7',
             NetworkType.TEST_NET,

--- a/test/infrastructure/SerializeTransactionToJSON.spec.ts
+++ b/test/infrastructure/SerializeTransactionToJSON.spec.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
+import { sha3_256 } from '@noble/hashes/sha3';
+import { bytesToHex } from '@noble/hashes/utils';
 import { expect } from 'chai';
-import { sha3_256 } from 'js-sha3';
 import { Crypto } from '../../src/core/crypto';
 import { Convert as convert, Convert } from '../../src/core/format';
 import { TransactionMapping } from '../../src/core/utils';
@@ -268,7 +269,7 @@ describe('SerializeTransactionToJSON', () => {
             NetworkCurrencyLocal.createAbsolute(10),
             UInt64.fromUint(100),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             recipientAddress,
             NetworkType.TEST_NET,
         );
@@ -284,7 +285,7 @@ describe('SerializeTransactionToJSON', () => {
         const secretProofTransaction = SecretProofTransaction.create(
             Deadline.create(epochAdjustment),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             account.address,
             proof,
             NetworkType.TEST_NET,
@@ -294,7 +295,7 @@ describe('SerializeTransactionToJSON', () => {
         expect(json.transaction.version).to.be.equal(1);
         expect(json.transaction.type).to.be.equal(TransactionType.SECRET_PROOF);
         expect(json.transaction.hashAlgorithm).to.be.equal(LockHashAlgorithm.Op_Sha3_256);
-        expect(json.transaction.secret).to.be.equal(sha3_256.create().update(convert.hexToUint8(proof)).hex());
+        expect(json.transaction.secret).to.be.equal(bytesToHex(sha3_256(convert.hexToUint8(proof))));
         expect(json.transaction.proof).to.be.equal(proof);
     });
 

--- a/test/model/transaction/HashTypeLengthValidator.spec.ts
+++ b/test/model/transaction/HashTypeLengthValidator.spec.ts
@@ -13,20 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { sha3_256, sha3_512 } from '@noble/hashes/sha3';
+import { bytesToHex } from '@noble/hashes/utils';
 import { expect } from 'chai';
 import * as CryptoJS from 'crypto-js';
-import { sha3_256, sha3_512 } from 'js-sha3';
 import { LockHashAlgorithm, LockHashAlgorithmLengthValidator } from '../../../src/model/lock/LockHashAlgorithm';
 
 describe('LockHashAlgorithmLengthValidator', () => {
     it('LockHashAlgorithm.SHA3_256 should be exactly 64 chars length', () => {
-        expect(LockHashAlgorithmLengthValidator(LockHashAlgorithm.Op_Sha3_256, sha3_256.create().update('abcxyz').hex())).to.be.equal(true);
+        expect(LockHashAlgorithmLengthValidator(LockHashAlgorithm.Op_Sha3_256, bytesToHex(sha3_256('abcxyz')))).to.be.equal(true);
     });
 
     it('LockHashAlgorithm.SHA3_256 should return false if it is not 64 chars length', () => {
-        expect(LockHashAlgorithmLengthValidator(LockHashAlgorithm.Op_Sha3_256, sha3_512.create().update('abcxyz').hex())).to.be.equal(
-            false,
-        );
+        expect(LockHashAlgorithmLengthValidator(LockHashAlgorithm.Op_Sha3_256, bytesToHex(sha3_512('abcxyz')))).to.be.equal(false);
     });
 
     it('LockHashAlgorithm.SHA_256 should return false if it is not a hash valid', () => {

--- a/test/model/transaction/SecretLockTransaction.spec.ts
+++ b/test/model/transaction/SecretLockTransaction.spec.ts
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { sha3_256 } from '@noble/hashes/sha3';
+import { bytesToHex } from '@noble/hashes/utils';
 import { deepEqual } from 'assert';
 import { expect } from 'chai';
 import * as CryptoJS from 'crypto-js';
-import { sha3_256 } from 'js-sha3';
 import { Convert, Convert as convert } from '../../../src/core/format';
 import { Account } from '../../../src/model/account/Account';
 import { Address } from '../../../src/model/account/Address';
@@ -68,7 +69,7 @@ describe('SecretLockTransaction', () => {
             NetworkCurrencyLocal.createAbsolute(10),
             UInt64.fromUint(100),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             TestAddress,
             TestNetworkType,
         );
@@ -84,7 +85,7 @@ describe('SecretLockTransaction', () => {
             NetworkCurrencyLocal.createAbsolute(10),
             UInt64.fromUint(100),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             TestAddress,
             TestNetworkType,
             new UInt64([1, 0]),
@@ -101,7 +102,7 @@ describe('SecretLockTransaction', () => {
             NetworkCurrencyLocal.createAbsolute(10),
             UInt64.fromUint(100),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             TestAddress,
             TestNetworkType,
         );
@@ -120,7 +121,7 @@ describe('SecretLockTransaction', () => {
             NetworkCurrencyLocal.createAbsolute(10),
             UInt64.fromUint(100),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             TestAddress,
             TestNetworkType,
         );
@@ -252,7 +253,7 @@ describe('SecretLockTransaction', () => {
             NetworkCurrencyLocal.createAbsolute(10),
             UInt64.fromUint(100),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             recipientAddress,
             TestNetworkType,
         );
@@ -271,7 +272,7 @@ describe('SecretLockTransaction', () => {
             NetworkCurrencyLocal.createAbsolute(10),
             UInt64.fromUint(100),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             TestAddress,
             TestNetworkType,
         ).setMaxFee(2);
@@ -290,7 +291,7 @@ describe('SecretLockTransaction', () => {
             new Mosaic(unresolvedMosaicId, UInt64.fromUint(1)),
             UInt64.fromUint(100),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             unresolvedAddress,
             '',
             account.publicAccount,
@@ -312,7 +313,7 @@ describe('SecretLockTransaction', () => {
             NetworkCurrencyLocal.createAbsolute(10),
             UInt64.fromUint(100),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             TestAddress,
             TestNetworkType,
         );
@@ -334,7 +335,7 @@ describe('SecretLockTransaction', () => {
             NetworkCurrencyLocal.createAbsolute(10),
             UInt64.fromUint(100),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             namespaceId,
             TestNetworkType,
         ).shouldNotifyAccount(namespaceId);

--- a/test/model/transaction/SecretProofTransaction.spec.ts
+++ b/test/model/transaction/SecretProofTransaction.spec.ts
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import { sha3_256 } from '@noble/hashes/sha3';
+import { bytesToHex } from '@noble/hashes/utils';
 import { EmbeddedTransactionBuilder } from 'catbuffer-typescript';
 import { expect } from 'chai';
 import * as CryptoJS from 'crypto-js';
-import { sha3_256 } from 'js-sha3';
 import { Convert, Convert as convert } from '../../../src/core/format';
 import { UInt64 } from '../../../src/model';
 import { Account, Address } from '../../../src/model/account';
@@ -51,7 +52,7 @@ describe('SecretProofTransaction', () => {
         const secretProofTransaction = SecretProofTransaction.create(
             Deadline.create(epochAdjustment),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             account.address,
             proof,
             NetworkType.TEST_NET,
@@ -66,7 +67,7 @@ describe('SecretProofTransaction', () => {
         const secretProofTransaction = SecretProofTransaction.create(
             Deadline.create(epochAdjustment),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             account.address,
             proof,
             NetworkType.TEST_NET,
@@ -82,7 +83,7 @@ describe('SecretProofTransaction', () => {
         const secretProofTransaction = SecretProofTransaction.create(
             Deadline.create(epochAdjustment),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             account.address,
             proof,
             NetworkType.TEST_NET,
@@ -185,7 +186,7 @@ describe('SecretProofTransaction', () => {
         const secretProofTransaction = SecretProofTransaction.create(
             Deadline.create(epochAdjustment),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             account.address,
             proof,
             NetworkType.TEST_NET,
@@ -204,7 +205,7 @@ describe('SecretProofTransaction', () => {
         const secretProofTransaction = SecretProofTransaction.create(
             Deadline.create(epochAdjustment),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             recipientAddress,
             proof,
             NetworkType.TEST_NET,
@@ -220,7 +221,7 @@ describe('SecretProofTransaction', () => {
         const secretProofTransaction = SecretProofTransaction.create(
             Deadline.create(epochAdjustment),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             account.address,
             proof,
             NetworkType.TEST_NET,
@@ -238,7 +239,7 @@ describe('SecretProofTransaction', () => {
             Deadline.create(epochAdjustment),
             UInt64.fromUint(0),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             unresolvedAddress,
             proof,
             '',
@@ -260,7 +261,7 @@ describe('SecretProofTransaction', () => {
             Deadline.create(epochAdjustment),
             UInt64.fromUint(0),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             unresolvedAddress,
             proof,
             '',
@@ -281,7 +282,7 @@ describe('SecretProofTransaction', () => {
         const secretProofTransaction = SecretProofTransaction.create(
             Deadline.create(epochAdjustment),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             account.address,
             proof,
             NetworkType.TEST_NET,
@@ -296,7 +297,7 @@ describe('SecretProofTransaction', () => {
         const tx = SecretProofTransaction.create(
             Deadline.create(epochAdjustment),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             account.address,
             proof,
             NetworkType.TEST_NET,
@@ -317,7 +318,7 @@ describe('SecretProofTransaction', () => {
         const canNotify = SecretProofTransaction.create(
             Deadline.create(epochAdjustment),
             LockHashAlgorithm.Op_Sha3_256,
-            sha3_256.create().update(convert.hexToUint8(proof)).hex(),
+            bytesToHex(sha3_256(convert.hexToUint8(proof))),
             namespaceId,
             proof,
             NetworkType.TEST_NET,


### PR DESCRIPTION
This will fix https://github.com/symbol/symbol-sdk-typescript-javascript/issues/622.

@noble/hashes is well maintained, and used by major blockchain libraries (e.g. @polkadot/util-crypto and @cosmjs/crypto).
https://www.npmjs.com/package/@noble/hashes