### PR TITLE
task: fix missing tx meta

### DIFF
--- a/src/infrastructure/transaction/CreateTransactionFromDTO.ts
+++ b/src/infrastructure/transaction/CreateTransactionFromDTO.ts
@@ -118,9 +118,25 @@ const extractTransactionMeta = (meta: any, id: string): TransactionInfo | Aggreg
         return undefined;
     }
     if (meta.aggregateHash || meta.aggregateId) {
-        return new AggregateTransactionInfo(UInt64.fromNumericString(meta.height), meta.index, id, meta.aggregateHash, meta.aggregateId);
+        return new AggregateTransactionInfo(
+            UInt64.fromNumericString(meta.height),
+            meta.index,
+            id,
+            UInt64.fromNumericString(meta.timestamp),
+            meta.feeMultiplier,
+            meta.aggregateHash,
+            meta.aggregateId,
+        );
     }
-    return new TransactionInfo(UInt64.fromNumericString(meta.height), meta.index, id, meta.hash, meta.merkleComponentHash);
+    return new TransactionInfo(
+        UInt64.fromNumericString(meta.height),
+        meta.index,
+        id,
+        UInt64.fromNumericString(meta.timestamp),
+        meta.feeMultiplier,
+        meta.hash,
+        meta.merkleComponentHash,
+    );
 };
 /**
  * @internal

--- a/src/model/transaction/AggregateTransactionInfo.ts
+++ b/src/model/transaction/AggregateTransactionInfo.ts
@@ -27,11 +27,15 @@ export class AggregateTransactionInfo extends TransactionInfo {
      * @param id
      * @param aggregateHash
      * @param aggregateId
+     * @param timestamp
+     * @param feeMultiplier
      */
     constructor(
         height: UInt64,
         index: number,
         id: string,
+        timestamp: UInt64,
+        feeMultiplier: number,
         /**
          * The hash of the aggregate transaction.
          */
@@ -41,6 +45,6 @@ export class AggregateTransactionInfo extends TransactionInfo {
          */
         public readonly aggregateId: string,
     ) {
-        super(height, index, id);
+        super(height, index, id, timestamp, feeMultiplier);
     }
 }

--- a/src/model/transaction/TransactionInfo.ts
+++ b/src/model/transaction/TransactionInfo.ts
@@ -24,6 +24,8 @@ export class TransactionInfo {
      * @param height
      * @param index
      * @param id
+     * @param timestamp
+     * @param feeMultiplier
      * @param hash
      * @param merkleComponentHash
      */
@@ -40,6 +42,14 @@ export class TransactionInfo {
          * The transaction db id.
          */
         public readonly id: string,
+        /**
+         * The transaction timestamp.
+         */
+        public readonly timestamp?: UInt64,
+        /**
+         * The transaction fee multiplier.
+         */
+        public readonly feeMultiplier?: number,
         /**
          * The transaction hash.
          */

--- a/test/infrastructure/Listener.spec.ts
+++ b/test/infrastructure/Listener.spec.ts
@@ -285,7 +285,7 @@ describe('Listener', () => {
                 );
                 const transferTransactionDTO = transferTransaction.toJSON();
                 const hash = 'abc';
-                transferTransactionDTO.meta = { height: '1', hash: hash };
+                transferTransactionDTO.meta = { height: '1', hash: hash, timestamp: '0', feeMultiplier: 0 };
 
                 const listener = new Listener('http://localhost:3000', namespaceRepo, WebSocketMultisigMock, multisigRepo);
                 listener.open();
@@ -315,7 +315,7 @@ describe('Listener', () => {
                 );
                 const transferTransactionDTO = transferTransaction.toJSON();
                 const hash = 'abc';
-                transferTransactionDTO.meta = { height: '1', hash: hash };
+                transferTransactionDTO.meta = { height: '1', hash: hash, timestamp: '0', feeMultiplier: 0 };
 
                 const reportedTransactions: Transaction[] = [];
                 const listener = new Listener('http://localhost:3000', namespaceRepo, WebSocketMockAlias);
@@ -334,7 +334,10 @@ describe('Listener', () => {
                 listener.handleMessage(
                     {
                         topic: name.toString(),
-                        data: { meta: { height: '2', hash: 'new hash' }, transaction: transferTransactionDTO.transaction },
+                        data: {
+                            meta: { height: '2', hash: 'new hash', timestamp: '2', feeMultiplier: 1 },
+                            transaction: transferTransactionDTO.transaction,
+                        },
                     },
                     null,
                 );
@@ -360,7 +363,7 @@ describe('Listener', () => {
                 const transferTransactionDTO = transferTransaction.toJSON();
                 const hash = 'abc';
                 const hash2 = 'abc2';
-                transferTransactionDTO.meta = { height: '1', hash: hash };
+                transferTransactionDTO.meta = { height: '1', hash: hash, timestamp: '0', feeMultiplier: 0 };
 
                 const reportedTransactions: Transaction[] = [];
                 const listener = new Listener('http://localhost:3000', namespaceRepo, WebSocketMock);
@@ -379,7 +382,10 @@ describe('Listener', () => {
                 listener.handleMessage(
                     {
                         topic: name.toString(),
-                        data: { meta: { height: '1', hash: 'new hash' }, transaction: transferTransactionDTO.transaction },
+                        data: {
+                            meta: { height: '1', hash: 'new hash', timestamp: '1', feeMultiplier: 1 },
+                            transaction: transferTransactionDTO.transaction,
+                        },
                     },
                     null,
                 );
@@ -399,7 +405,7 @@ describe('Listener', () => {
                 );
                 const transferTransactionDTO = transferTransaction.toJSON();
                 const hash = 'abc';
-                transferTransactionDTO.meta = { height: '1', hash: hash };
+                transferTransactionDTO.meta = { height: '1', hash: hash, timestamp: '0', feeMultiplier: 0 };
 
                 const reportedTransactions: Transaction[] = [];
                 const listener = new Listener('http://localhost:3000', namespaceRepo, WebSocketMockAlias);
@@ -418,7 +424,10 @@ describe('Listener', () => {
                 listener.handleMessage(
                     {
                         topic: name.toString(),
-                        data: { meta: { height: '1', hash: 'new hash' }, transaction: transferTransactionDTO.transaction },
+                        data: {
+                            meta: { height: '1', hash: 'new hash', timestamp: '1', feeMultiplier: 1 },
+                            transaction: transferTransactionDTO.transaction,
+                        },
                     },
                     null,
                 );
@@ -438,7 +447,7 @@ describe('Listener', () => {
                 );
                 const transferTransactionDTO = transferTransaction.toJSON();
                 const hash = 'abc';
-                transferTransactionDTO.meta = { height: '1', hash: hash };
+                transferTransactionDTO.meta = { height: '1', hash: hash, timestamp: '0', feeMultiplier: 0 };
 
                 const reportedTransactions: Transaction[] = [];
 
@@ -458,7 +467,10 @@ describe('Listener', () => {
                 listener.handleMessage(
                     {
                         topic: name.toString(),
-                        data: { meta: { height: '1', hash: 'new hash' }, transaction: transferTransactionDTO.transaction },
+                        data: {
+                            meta: { height: '1', hash: 'new hash', timestamp: '1', feeMultiplier: 1 },
+                            transaction: transferTransactionDTO.transaction,
+                        },
                     },
                     null,
                 );
@@ -487,7 +499,7 @@ describe('Listener', () => {
                 );
                 const transferTransactionDTO = transferTransaction.toJSON();
                 const hash = 'abc';
-                transferTransactionDTO.meta = { height: '1', hash: hash };
+                transferTransactionDTO.meta = { height: '1', hash: hash, timestamp: '0', feeMultiplier: 0 };
 
                 const reportedTransactions: Transaction[] = [];
 
@@ -507,7 +519,10 @@ describe('Listener', () => {
                 listener.handleMessage(
                     {
                         topic: name.toString(),
-                        data: { meta: { height: '1', hash: 'new hash' }, transaction: transferTransactionDTO.transaction },
+                        data: {
+                            meta: { height: '1', hash: 'new hash', timestamp: '1', feeMultiplier: 1 },
+                            transaction: transferTransactionDTO.transaction,
+                        },
                     },
                     null,
                 );

--- a/test/infrastructure/TransactionHttp.spec.ts
+++ b/test/infrastructure/TransactionHttp.spec.ts
@@ -101,6 +101,8 @@ describe('TransactionHttp', () => {
         metaDto.hash = 'hash';
         metaDto.height = '1';
         metaDto.index = 0;
+        metaDto.timestamp = '0';
+        metaDto.feeMultiplier = 0;
         metaDto.merkleComponentHash = 'merkleHash';
 
         const transactionDto = {} as TransferTransactionDTO;
@@ -186,6 +188,8 @@ describe('TransactionHttp', () => {
         expect(((transactions.data[0] as TransferTransaction).recipientAddress as Address).plain()).to.be.equal(TestAddress.plain());
         expect(transactions.data[0].transactionInfo?.id).to.be.equal('id');
         expect(transactions.data[0].transactionInfo?.hash).to.be.equal('hash');
+        expect(transactions.data[0].transactionInfo?.timestamp?.toString()).to.be.equal('0');
+        expect(transactions.data[0].transactionInfo?.feeMultiplier).to.be.equal(0);
 
         expect(transactions.pageNumber).to.be.equal(1);
         expect(transactions.pageSize).to.be.equal(1);
@@ -219,6 +223,8 @@ describe('TransactionHttp', () => {
         metaDto.hash = 'hash';
         metaDto.height = '1';
         metaDto.index = 0;
+        metaDto.timestamp = '0';
+        metaDto.feeMultiplier = 0;
         metaDto.merkleComponentHash = 'merkleHash';
 
         const transactionDto = {} as TransferTransactionDTO;
@@ -245,6 +251,8 @@ describe('TransactionHttp', () => {
         expect(((transaction as TransferTransaction).recipientAddress as Address).plain()).to.be.equal(TestAddress.plain());
         expect(transaction.transactionInfo?.id).to.be.equal('id');
         expect(transaction.transactionInfo?.hash).to.be.equal('hash');
+        expect(transaction.transactionInfo?.timestamp?.toString()).to.be.equal('0');
+        expect(transaction.transactionInfo?.feeMultiplier).to.be.equal(0);
 
         transaction = await firstValueFrom(transactionHttp.getTransaction(generationHash, TransactionGroup.Partial));
 
@@ -252,7 +260,6 @@ describe('TransactionHttp', () => {
         expect(((transaction as TransferTransaction).recipientAddress as Address).plain()).to.be.equal(TestAddress.plain());
         expect(transaction.transactionInfo?.id).to.be.equal('id');
         expect(transaction.transactionInfo?.hash).to.be.equal('hash');
-
         transaction = await firstValueFrom(transactionHttp.getTransaction(generationHash, TransactionGroup.Unconfirmed));
 
         expect(transaction.type.valueOf()).to.be.equal(TransactionType.TRANSFER.valueOf());
@@ -267,6 +274,8 @@ describe('TransactionHttp', () => {
         metaDto.hash = 'hash';
         metaDto.height = '1';
         metaDto.index = 0;
+        metaDto.timestamp = '0';
+        metaDto.feeMultiplier = 0;
         metaDto.merkleComponentHash = 'merkleHash';
 
         const transactionDto = {} as TransferTransactionDTO;
@@ -309,6 +318,8 @@ describe('TransactionHttp', () => {
         expect(((transactionConfirmed[0] as TransferTransaction).recipientAddress as Address).plain()).to.be.equal(TestAddress.plain());
         expect(transactionConfirmed[0].transactionInfo?.id).to.be.equal('id');
         expect(transactionConfirmed[0].transactionInfo?.hash).to.be.equal('hash');
+        expect(transactionConfirmed[0].transactionInfo?.timestamp?.toString()).to.be.equal('0');
+        expect(transactionConfirmed[0].transactionInfo?.feeMultiplier).to.be.equal(0);
 
         expect(transactionUnconfirmed.length).to.be.equal(1);
         expect(transactionUnconfirmed[0].type.valueOf()).to.be.equal(TransactionType.TRANSFER.valueOf());
@@ -330,6 +341,8 @@ describe('TransactionHttp', () => {
         metaDto.height = '1';
         metaDto.index = 0;
         metaDto.merkleComponentHash = 'merkleHash';
+        metaDto.timestamp = '0';
+        metaDto.feeMultiplier = 0;
 
         const transactionDto = {} as TransferTransactionDTO;
         transactionDto.deadline = '1';

--- a/test/infrastructure/transaction/CreateTransactionFromDTO.spec.ts
+++ b/test/infrastructure/transaction/CreateTransactionFromDTO.spec.ts
@@ -59,6 +59,8 @@ describe('CreateTransactionFromDTO', () => {
                     hash: '533243B8575C4058F894C453160AFF055A4A905978AC331460F44104D831E4AC',
                     merkleComponentHash: '533243B8575C4058F894C453160AFF055A4A905978AC331460F44104D831E4AC',
                     index: 0,
+                    timestamp: '0',
+                    feeMultiplier: 0,
                 },
                 transaction: transactionDto,
             };
@@ -78,6 +80,8 @@ describe('CreateTransactionFromDTO', () => {
                     hash: '533243B8575C4058F894C453160AFF055A4A905978AC331460F44104D831E4AC',
                     merkleComponentHash: '533243B8575C4058F894C453160AFF055A4A905978AC331460F44104D831E4AC',
                     index: 0,
+                    timestamp: '0',
+                    feeMultiplier: 0,
                 },
                 transaction: {
                     size: 100,
@@ -113,6 +117,8 @@ describe('CreateTransactionFromDTO', () => {
                     height: '1860',
                     index: 0,
                     merkleComponentHash: '81E5E7AE49998802DABC816EC10158D3A7879702FF29084C2C992CD1289877A7',
+                    timestamp: '0',
+                    feeMultiplier: 0,
                 },
                 transaction: {
                     size: 100,
@@ -139,6 +145,8 @@ describe('CreateTransactionFromDTO', () => {
                                 aggregateId: '5A0069D83F17CF0001777E55',
                                 height: '1860',
                                 index: 0,
+                                timestamp: '0',
+                                feeMultiplier: 0,
                             },
                             transaction: {
                                 message: '00746573742D6D657373616765',
@@ -177,6 +185,8 @@ describe('CreateTransactionFromDTO', () => {
                     aggregateHash: 'D6A48BFD66920825D748D2CF92B025588F3A030C98633C442B4704BF407160B9',
                     aggregateId: '5F729AA24655A25B54840CB7',
                     index: 0,
+                    timestamp: '0',
+                    feeMultiplier: 0,
                 },
                 transaction: {
                     signerPublicKey: '2FC3872A792933617D70E02AFF8FBDE152821A0DF0CA5FB04CB56FC3D21C8863',
@@ -212,6 +222,8 @@ describe('CreateTransactionFromDTO', () => {
                         height: '1',
                         index: 19,
                         merkleComponentHash: '18C036C20B32348D63684E09A13128A2C18F6A75650D3A5FB43853D716E5E219',
+                        timestamp: '0',
+                        feeMultiplier: 0,
                     },
                     transaction: {
                         size: 100,
@@ -244,6 +256,8 @@ describe('CreateTransactionFromDTO', () => {
                         height: '1860',
                         index: 0,
                         merkleComponentHash: '81E5E7AE49998802DABC816EC10158D3A7879702FF29084C2C992CD1289877A7',
+                        timestamp: '0',
+                        feeMultiplier: 0,
                     },
                     transaction: {
                         size: 100,
@@ -270,6 +284,8 @@ describe('CreateTransactionFromDTO', () => {
                                     aggregateId: '5A0069D83F17CF0001777E55',
                                     height: '1860',
                                     index: 0,
+                                    timestamp: '0',
+                                    feeMultiplier: 0,
                                 },
                                 transaction: {
                                     duration: '1000',
@@ -307,6 +323,8 @@ describe('CreateTransactionFromDTO', () => {
                         height: '1',
                         index: 19,
                         merkleComponentHash: '18C036C20B32348D63684E09A13128A2C18F6A75650D3A5FB43853D716E5E219',
+                        timestamp: '0',
+                        feeMultiplier: 0,
                     },
                     transaction: {
                         size: 100,
@@ -338,6 +356,8 @@ describe('CreateTransactionFromDTO', () => {
                         height: '1860',
                         index: 0,
                         merkleComponentHash: '81E5E7AE49998802DABC816EC10158D3A7879702FF29084C2C992CD1289877A7',
+                        timestamp: '0',
+                        feeMultiplier: 0,
                     },
                     transaction: {
                         size: 100,
@@ -364,6 +384,8 @@ describe('CreateTransactionFromDTO', () => {
                                     aggregateId: '5A0069D83F17CF0001777E55',
                                     height: '1860',
                                     index: 0,
+                                    timestamp: '0',
+                                    feeMultiplier: 0,
                                 },
                                 transaction: {
                                     name: '0unius',
@@ -402,6 +424,8 @@ describe('CreateTransactionFromDTO', () => {
                     height: '1',
                     index: 19,
                     merkleComponentHash: '18C036C20B32348D63684E09A13128A2C18F6A75650D3A5FB43853D716E5E219',
+                    timestamp: '0',
+                    feeMultiplier: 0,
                 },
                 transaction: {
                     size: 100,
@@ -436,6 +460,8 @@ describe('CreateTransactionFromDTO', () => {
                     height: '1860',
                     index: 0,
                     merkleComponentHash: '81E5E7AE49998802DABC816EC10158D3A7879702FF29084C2C992CD1289877A7',
+                    timestamp: '0',
+                    feeMultiplier: 0,
                 },
                 transaction: {
                     size: 100,
@@ -462,6 +488,8 @@ describe('CreateTransactionFromDTO', () => {
                                 aggregateId: '5A0069D83F17CF0001777E55',
                                 height: '1860',
                                 index: 0,
+                                timestamp: '0',
+                                feeMultiplier: 0,
                             },
                             transaction: {
                                 id: '85BBEA6CC462B244',
@@ -497,6 +525,8 @@ describe('CreateTransactionFromDTO', () => {
                     height: '1',
                     index: 19,
                     merkleComponentHash: '18C036C20B32348D63684E09A13128A2C18F6A75650D3A5FB43853D716E5E219',
+                    timestamp: '0',
+                    feeMultiplier: 0,
                 },
                 transaction: {
                     size: 100,
@@ -528,6 +558,8 @@ describe('CreateTransactionFromDTO', () => {
                     height: '1860',
                     index: 0,
                     merkleComponentHash: '81E5E7AE49998802DABC816EC10158D3A7879702FF29084C2C992CD1289877A7',
+                    timestamp: '0',
+                    feeMultiplier: 0,
                 },
                 transaction: {
                     size: 100,
@@ -554,6 +586,8 @@ describe('CreateTransactionFromDTO', () => {
                                 aggregateId: '5A0069D83F17CF0001777E55',
                                 height: '1860',
                                 index: 0,
+                                timestamp: '0',
+                                feeMultiplier: 0,
                             },
                             transaction: {
                                 delta: '1000',
@@ -623,6 +657,8 @@ describe('CreateTransactionFromDTO', () => {
                     height: '1',
                     index: 19,
                     merkleComponentHash: '18C036C20B32348D63684E09A13128A2C18F6A75650D3A5FB43853D716E5E219',
+                    timestamp: '0',
+                    feeMultiplier: 0,
                 },
                 transaction: {
                     size: 100,
@@ -655,6 +691,8 @@ describe('CreateTransactionFromDTO', () => {
                     height: '1860',
                     index: 0,
                     merkleComponentHash: '81E5E7AE49998802DABC816EC10158D3A7879702FF29084C2C992CD1289877A7',
+                    timestamp: '0',
+                    feeMultiplier: 0,
                 },
                 transaction: {
                     size: 100,
@@ -681,6 +719,8 @@ describe('CreateTransactionFromDTO', () => {
                                 aggregateId: '5A0069D83F17CF0001777E55',
                                 height: '1860',
                                 index: 0,
+                                timestamp: '0',
+                                feeMultiplier: 0,
                             },
                             transaction: {
                                 minApprovalDelta: 1,
@@ -724,12 +764,16 @@ describe('CreateTransactionFromDTO', () => {
         const testTxIndex = 0;
         const testTxSize = 100;
         const testTxMaxFee = '0';
+        const testTxTimestamp = '0';
+        const testTxFeeMultiplier = 0;
 
         // aggregate tx constants
         const testAggTxId = '5A0069D83F17CF0001777E55';
         const testAggTxHash = '671653C94E2254F2A23EFEDB15D67C38332AED1FBD24B063C0A8E675582B6A96';
         const testAggTxHeight = '1860';
         const testAggTxIndex = 0;
+        const testAggTxTimestamp = '0';
+        const testAggTxFeeMultiplier = 0;
         const testAggMerkleComponentHash = '81E5E7AE49998802DABC816EC10158D3A7879702FF29084C2C992CD1289877A7';
         const testAggTxSize = 100;
         const testAggTxCosigSignature =
@@ -762,6 +806,8 @@ describe('CreateTransactionFromDTO', () => {
                 hash: testAggTxHash,
                 height: testAggTxHeight,
                 index: testAggTxIndex,
+                timestamp: testAggTxTimestamp,
+                feeMultiplier: testAggTxFeeMultiplier,
                 merkleComponentHash: testAggMerkleComponentHash,
             },
             transaction: {
@@ -785,6 +831,8 @@ describe('CreateTransactionFromDTO', () => {
                             aggregateId: testAggTxId,
                             height: testAggTxHeight,
                             index: testAggTxIndex,
+                            timestamp: testAggTxTimestamp,
+                            feeMultiplier: testAggTxFeeMultiplier,
                         },
                         transaction: innerTransaction,
                     },
@@ -802,6 +850,8 @@ describe('CreateTransactionFromDTO', () => {
                 hash: testTxHash,
                 merkleComponentHash: testTxMerkleComponentHash,
                 index: testTxIndex,
+                timestamp: testTxTimestamp,
+                feeMultiplier: testTxFeeMultiplier,
             },
             transaction: transactionDto,
         });

--- a/test/model/transaction/AggregateTransaction.spec.ts
+++ b/test/model/transaction/AggregateTransaction.spec.ts
@@ -311,6 +311,8 @@ describe('AggregateTransaction', () => {
                 id: '5A0069D83F17CF0001777E55',
                 index: 0,
                 merkleComponentHash: '81E5E7AE49998802DABC816EC10158D3A7879702FF29084C2C992CD1289877A7',
+                timestamp: '0',
+                feeMultiplier: 0,
             },
             transaction: {
                 cosignatures: [
@@ -336,6 +338,8 @@ describe('AggregateTransaction', () => {
                             height: '18160',
                             id: '5A0069D83F17CF0001777E56',
                             index: 0,
+                            timestamp: '0',
+                            feeMultiplier: 0,
                         },
                         transaction: {
                             minApprovalDelta: 1,

--- a/test/model/transaction/CosignatureTransaction.spec.ts
+++ b/test/model/transaction/CosignatureTransaction.spec.ts
@@ -40,6 +40,8 @@ describe('CosignatureTransaction', () => {
             id: '5A0069D83F17CF0001777E55',
             index: 0,
             merkleComponentHash: '81E5E7AE49998802DABC816EC10158D3A7879702FF29084C2C992CD1289877A7',
+            timestamp: '0',
+            feeMultiplier: 0,
         },
         transaction: {
             cosignatures: [
@@ -65,6 +67,8 @@ describe('CosignatureTransaction', () => {
                         height: '18160',
                         id: '5A0069D83F17CF0001777E56',
                         index: 0,
+                        timestamp: '0',
+                        feeMultiplier: 0,
                     },
                     transaction: {
                         message: '00746573742D6D657373616765',
@@ -174,6 +178,8 @@ describe('CosignatureTransaction', () => {
                 id: '5A0069D83F17CF0001777E55',
                 index: 0,
                 merkleComponentHash: '81E5E7AE49998802DABC816EC10158D3A7879702FF29084C2C992CD1289877A7',
+                timestamp: '0',
+                feeMultiplier: 0,
             },
         });
         const aggregate = CreateTransactionFromDTO(aggregateTransferTransactionDTO) as AggregateTransaction;

--- a/test/model/transaction/Transaction.spec.ts
+++ b/test/model/transaction/Transaction.spec.ts
@@ -96,7 +96,7 @@ describe('Transaction', () => {
                 UInt64.fromUint(0),
                 undefined,
                 undefined,
-                new TransactionInfo(UInt64.fromUint(0), 1, 'id_hash', 'hash', 'hash'),
+                new TransactionInfo(UInt64.fromUint(0), 1, 'id_hash', UInt64.fromUint(0), 0, 'hash', 'hash'),
             );
             expect(transaction.isUnconfirmed()).to.be.equal(true);
         });
@@ -110,7 +110,7 @@ describe('Transaction', () => {
                 UInt64.fromUint(0),
                 undefined,
                 undefined,
-                new TransactionInfo(UInt64.fromUint(100), 1, 'id_hash', 'hash', 'hash'),
+                new TransactionInfo(UInt64.fromUint(100), 1, 'id_hash', UInt64.fromUint(100), 0, 'hash', 'hash'),
             );
             expect(transaction.isUnconfirmed()).to.be.equal(false);
         });
@@ -126,7 +126,7 @@ describe('Transaction', () => {
                 UInt64.fromUint(0),
                 undefined,
                 undefined,
-                new TransactionInfo(UInt64.fromUint(100), 1, 'id_hash', 'hash', 'hash'),
+                new TransactionInfo(UInt64.fromUint(100), 1, 'id_hash', UInt64.fromUint(100), 0, 'hash', 'hash'),
             );
             expect(transaction.isConfirmed()).to.be.equal(true);
         });
@@ -142,7 +142,7 @@ describe('Transaction', () => {
                 UInt64.fromUint(0),
                 undefined,
                 undefined,
-                new TransactionInfo(UInt64.fromUint(0), 1, 'id_hash', 'hash', 'hash_2'),
+                new TransactionInfo(UInt64.fromUint(0), 1, 'id_hash', UInt64.fromUint(0), 0, 'hash', 'hash_2'),
             );
             expect(transaction.hasMissingSignatures()).to.be.equal(true);
         });
@@ -158,7 +158,7 @@ describe('Transaction', () => {
                 UInt64.fromUint(0),
                 undefined,
                 undefined,
-                new TransactionInfo(UInt64.fromUint(100), 1, 'id_hash', 'hash', 'hash'),
+                new TransactionInfo(UInt64.fromUint(100), 1, 'id_hash', UInt64.fromUint(100), 0, 'hash', 'hash'),
             );
             expect(() => {
                 transaction.reapplyGiven(Deadline.create(epochAdjustment));
@@ -251,7 +251,7 @@ describe('Transaction', () => {
                 UInt64.fromUint(0),
                 undefined,
                 undefined,
-                new TransactionInfo(UInt64.fromUint(100), 1, 'id_hash', 'hash', 'hash'),
+                new TransactionInfo(UInt64.fromUint(100), 1, 'id_hash', UInt64.fromUint(100), 0, 'hash', 'hash'),
             );
             expect(transaction.versionToHex()).to.be.equal('0x9801');
         });

--- a/test/model/transaction/TransferTransaction.spec.ts
+++ b/test/model/transaction/TransferTransaction.spec.ts
@@ -326,6 +326,8 @@ describe('TransferTransaction', () => {
                 hash: '9661088F22C2DC72E76EE2B0F07BFC0D8E98EEE0CC8AE274362EDBB44F164F16',
                 merkleComponentHash: '9661088F22C2DC72E76EE2B0F07BFC0D8E98EEE0CC8AE274362EDBB44F164F16',
                 index: 0,
+                timestamp: '0',
+                feeMultiplier: 0,
             },
             transaction: {
                 size: 292,

--- a/test/service/BlockService.spec.ts
+++ b/test/service/BlockService.spec.ts
@@ -130,7 +130,14 @@ describe('BlockService', () => {
             PlainMessage.create(''),
             undefined,
             undefined,
-            new TransactionInfo(UInt64.fromUint(1), 0, 'id', 'DCD14A040BC5096348FC55CACBD0D459DD6F81779C7E7C526EA52309BD6595F7'),
+            new TransactionInfo(
+                UInt64.fromUint(1),
+                0,
+                'id',
+                UInt64.fromUint(0),
+                0,
+                'DCD14A040BC5096348FC55CACBD0D459DD6F81779C7E7C526EA52309BD6595F7',
+            ),
         );
         return new Page<Transaction>([tx], 1, 20);
     }


### PR DESCRIPTION
### What was the issue?
- The SDK transaction DTO was missing some info such as meta's `timestamp` and `feeMultiplier`.

### What's the fix?
- added missing properties in transaction dto

```
{
    ...
    feeMultiplier: number,
    timestamp: UInt64
}
```
- update all the unit test
