### PR TITLE
docs: update change log 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.0.2 - 7-Oct-2022
+
+**Milestone**: Symbol Mainnet
+Package  | Version  | Link
+---|---|---
+SDK Core| v2.0.2 | [symbol-sdk](https://www.npmjs.com/package/symbol-sdk)
+Catbuffer | v1.0.1 | [catbuffer-typescript](https://www.npmjs.com/package/catbuffer-typescript)
+Client Library | v1.0.3  | [symbol-openapi-typescript-fetch-client](https://www.npmjs.com/package/symbol-openapi-typescript-fetch-client)
+
+[Bug] [#843](https://github.com/symbol/symbol-sdk-typescript-javascript/pull/843): Handle transaction meta's timestamp and feeMultiplier when value is undefined.
+
 ## 2.0.1 - 30-May-2022
 
 **Milestone**: Symbol Mainnet
@@ -39,7 +50,7 @@ SDK Core| v1.0.3 | [symbol-sdk](https://www.npmjs.com/package/symbol-sdk)
 Catbuffer | v1.0.1 | [catbuffer-typescript](https://www.npmjs.com/package/catbuffer-typescript)
 Client Library | v1.0.3  | [symbol-openapi-typescript-fetch-client](https://www.npmjs.com/package/symbol-openapi-typescript-fetch-client)
 
-- fix: replaced `instanceof` statements. These statements are problematic when npm installs the dependency in multiples modules. 
+- fix: replaced `instanceof` statements. These statements are problematic when npm installs the dependency in multiples modules.
 - feat: added mosaic revocation support.
 
 ## [1.0.2] - 25-Oct-2021
@@ -53,8 +64,8 @@ Client Library | v1.0.2 | [symbol-openapi-typescript-fetch-client](https://www.n
 
 - feat: Multisig multilevel subscription in web listener.
 - feat: Added Deployment data to `ServerInfo`.
-- fix: Fixed observable pipe in `TransactionService`'s announce method. 
-- fix: Allowing plain base32 addresses in rest payloads. Both address formats are supported. 
+- fix: Fixed observable pipe in `TransactionService`'s announce method.
+- fix: Allowing plain base32 addresses in rest payloads. Both address formats are supported.
 - fix: Cosigning from transaction hash only.
 - fix: Transaction `signWith` method broken into smaller methods.
 - fix: Removed unsued dependencies.
@@ -748,7 +759,7 @@ Client Library | v0.7.20-alpha.6  | [nem2-sdk-openapi-typescript-node-client](ht
 
 **Milestone**: Cow
 
-- Fixed #125, maxFee DTO value errors with in-aggregate MosaicSupplyChange and HashLock transactions  
+- Fixed #125, maxFee DTO value errors with in-aggregate MosaicSupplyChange and HashLock transactions
 
 ## [0.11.4] - 17-Apr-2019
 


### PR DESCRIPTION
## Release note 2.0.2

[Bug] [#843](https://github.com/symbol/symbol-sdk-typescript-javascript/pull/843): Handle transaction meta's timestamp and feeMultiplier when value is undefined.
