### PR TITLE
Release v2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.0.2 - 7-Oct-2022
+
+**Milestone**: Symbol Mainnet
+Package  | Version  | Link
+---|---|---
+SDK Core| v2.0.2 | [symbol-sdk](https://www.npmjs.com/package/symbol-sdk)
+Catbuffer | v1.0.1 | [catbuffer-typescript](https://www.npmjs.com/package/catbuffer-typescript)
+Client Library | v1.0.3  | [symbol-openapi-typescript-fetch-client](https://www.npmjs.com/package/symbol-openapi-typescript-fetch-client)
+
+[Bug] [#843](https://github.com/symbol/symbol-sdk-typescript-javascript/pull/843): Handle transaction meta's timestamp and feeMultiplier when value is undefined.
+
 ## 2.0.1 - 30-May-2022
 
 **Milestone**: Symbol Mainnet
@@ -39,7 +50,7 @@ SDK Core| v1.0.3 | [symbol-sdk](https://www.npmjs.com/package/symbol-sdk)
 Catbuffer | v1.0.1 | [catbuffer-typescript](https://www.npmjs.com/package/catbuffer-typescript)
 Client Library | v1.0.3  | [symbol-openapi-typescript-fetch-client](https://www.npmjs.com/package/symbol-openapi-typescript-fetch-client)
 
-- fix: replaced `instanceof` statements. These statements are problematic when npm installs the dependency in multiples modules. 
+- fix: replaced `instanceof` statements. These statements are problematic when npm installs the dependency in multiples modules.
 - feat: added mosaic revocation support.
 
 ## [1.0.2] - 25-Oct-2021
@@ -53,8 +64,8 @@ Client Library | v1.0.2 | [symbol-openapi-typescript-fetch-client](https://www.n
 
 - feat: Multisig multilevel subscription in web listener.
 - feat: Added Deployment data to `ServerInfo`.
-- fix: Fixed observable pipe in `TransactionService`'s announce method. 
-- fix: Allowing plain base32 addresses in rest payloads. Both address formats are supported. 
+- fix: Fixed observable pipe in `TransactionService`'s announce method.
+- fix: Allowing plain base32 addresses in rest payloads. Both address formats are supported.
 - fix: Cosigning from transaction hash only.
 - fix: Transaction `signWith` method broken into smaller methods.
 - fix: Removed unsued dependencies.
@@ -748,7 +759,7 @@ Client Library | v0.7.20-alpha.6  | [nem2-sdk-openapi-typescript-node-client](ht
 
 **Milestone**: Cow
 
-- Fixed #125, maxFee DTO value errors with in-aggregate MosaicSupplyChange and HashLock transactions  
+- Fixed #125, maxFee DTO value errors with in-aggregate MosaicSupplyChange and HashLock transactions
 
 ## [0.11.4] - 17-Apr-2019
 

--- a/src/infrastructure/transaction/CreateTransactionFromDTO.ts
+++ b/src/infrastructure/transaction/CreateTransactionFromDTO.ts
@@ -122,8 +122,8 @@ const extractTransactionMeta = (meta: any, id: string): TransactionInfo | Aggreg
             UInt64.fromNumericString(meta.height),
             meta.index,
             id,
-            UInt64.fromNumericString(meta.timestamp),
-            meta.feeMultiplier,
+            UInt64.fromNumericString(meta.timestamp ?? '0'),
+            meta.feeMultiplier ?? 0,
             meta.aggregateHash,
             meta.aggregateId,
         );
@@ -132,8 +132,8 @@ const extractTransactionMeta = (meta: any, id: string): TransactionInfo | Aggreg
         UInt64.fromNumericString(meta.height),
         meta.index,
         id,
-        UInt64.fromNumericString(meta.timestamp),
-        meta.feeMultiplier,
+        UInt64.fromNumericString(meta.timestamp ?? '0'),
+        meta.feeMultiplier ?? 0,
         meta.hash,
         meta.merkleComponentHash,
     );

--- a/test/infrastructure/TransactionHttp.spec.ts
+++ b/test/infrastructure/TransactionHttp.spec.ts
@@ -101,8 +101,6 @@ describe('TransactionHttp', () => {
         metaDto.hash = 'hash';
         metaDto.height = '1';
         metaDto.index = 0;
-        metaDto.timestamp = '0';
-        metaDto.feeMultiplier = 0;
         metaDto.merkleComponentHash = 'merkleHash';
 
         const transactionDto = {} as TransferTransactionDTO;
@@ -139,7 +137,22 @@ describe('TransactionHttp', () => {
                 undefined,
                 undefined,
             ),
-        ).thenReturn(Promise.resolve(page));
+        ).thenReturn(
+            Promise.resolve({
+                data: [
+                    {
+                        id: 'id',
+                        meta: {
+                            ...metaDto,
+                            feeMultiplier: 100,
+                            timestamp: '1000',
+                        },
+                        transaction: transactionDto,
+                    },
+                ],
+                pagination: paginationDto,
+            }),
+        );
 
         when(
             transactionRoutesApi.searchPartialTransactions(
@@ -188,8 +201,8 @@ describe('TransactionHttp', () => {
         expect(((transactions.data[0] as TransferTransaction).recipientAddress as Address).plain()).to.be.equal(TestAddress.plain());
         expect(transactions.data[0].transactionInfo?.id).to.be.equal('id');
         expect(transactions.data[0].transactionInfo?.hash).to.be.equal('hash');
-        expect(transactions.data[0].transactionInfo?.timestamp?.toString()).to.be.equal('0');
-        expect(transactions.data[0].transactionInfo?.feeMultiplier).to.be.equal(0);
+        expect(transactions.data[0].transactionInfo?.timestamp?.toString()).to.be.equal('1000');
+        expect(transactions.data[0].transactionInfo?.feeMultiplier).to.be.equal(100);
 
         expect(transactions.pageNumber).to.be.equal(1);
         expect(transactions.pageSize).to.be.equal(1);
@@ -201,6 +214,8 @@ describe('TransactionHttp', () => {
         expect(((transactions.data[0] as TransferTransaction).recipientAddress as Address).plain()).to.be.equal(TestAddress.plain());
         expect(transactions.data[0].transactionInfo?.id).to.be.equal('id');
         expect(transactions.data[0].transactionInfo?.hash).to.be.equal('hash');
+        expect(transactions.data[0].transactionInfo?.timestamp?.toString()).to.be.equal('0');
+        expect(transactions.data[0].transactionInfo?.feeMultiplier).to.be.equal(0);
 
         expect(transactions.pageNumber).to.be.equal(1);
         expect(transactions.pageSize).to.be.equal(1);
@@ -212,6 +227,8 @@ describe('TransactionHttp', () => {
         expect(((transactions.data[0] as TransferTransaction).recipientAddress as Address).plain()).to.be.equal(TestAddress.plain());
         expect(transactions.data[0].transactionInfo?.id).to.be.equal('id');
         expect(transactions.data[0].transactionInfo?.hash).to.be.equal('hash');
+        expect(transactions.data[0].transactionInfo?.timestamp?.toString()).to.be.equal('0');
+        expect(transactions.data[0].transactionInfo?.feeMultiplier).to.be.equal(0);
 
         expect(transactions.pageNumber).to.be.equal(1);
         expect(transactions.pageSize).to.be.equal(1);
@@ -223,8 +240,6 @@ describe('TransactionHttp', () => {
         metaDto.hash = 'hash';
         metaDto.height = '1';
         metaDto.index = 0;
-        metaDto.timestamp = '0';
-        metaDto.feeMultiplier = 0;
         metaDto.merkleComponentHash = 'merkleHash';
 
         const transactionDto = {} as TransferTransactionDTO;
@@ -240,7 +255,17 @@ describe('TransactionHttp', () => {
         transactionInfoDto.meta = metaDto;
         transactionInfoDto.transaction = transactionDto;
 
-        when(transactionRoutesApi.getConfirmedTransaction(generationHash)).thenReturn(Promise.resolve(transactionInfoDto));
+        when(transactionRoutesApi.getConfirmedTransaction(generationHash)).thenReturn(
+            Promise.resolve({
+                id: 'id',
+                meta: {
+                    ...metaDto,
+                    feeMultiplier: 100,
+                    timestamp: '1000',
+                },
+                transaction: transactionDto,
+            }),
+        );
 
         when(transactionRoutesApi.getPartialTransaction(generationHash)).thenReturn(Promise.resolve(transactionInfoDto));
         when(transactionRoutesApi.getUnconfirmedTransaction(generationHash)).thenReturn(Promise.resolve(transactionInfoDto));
@@ -251,8 +276,8 @@ describe('TransactionHttp', () => {
         expect(((transaction as TransferTransaction).recipientAddress as Address).plain()).to.be.equal(TestAddress.plain());
         expect(transaction.transactionInfo?.id).to.be.equal('id');
         expect(transaction.transactionInfo?.hash).to.be.equal('hash');
-        expect(transaction.transactionInfo?.timestamp?.toString()).to.be.equal('0');
-        expect(transaction.transactionInfo?.feeMultiplier).to.be.equal(0);
+        expect(transaction.transactionInfo?.timestamp?.toString()).to.be.equal('1000');
+        expect(transaction.transactionInfo?.feeMultiplier).to.be.equal(100);
 
         transaction = await firstValueFrom(transactionHttp.getTransaction(generationHash, TransactionGroup.Partial));
 
@@ -260,12 +285,17 @@ describe('TransactionHttp', () => {
         expect(((transaction as TransferTransaction).recipientAddress as Address).plain()).to.be.equal(TestAddress.plain());
         expect(transaction.transactionInfo?.id).to.be.equal('id');
         expect(transaction.transactionInfo?.hash).to.be.equal('hash');
+        expect(transaction.transactionInfo?.timestamp?.toString()).to.be.equal('0');
+        expect(transaction.transactionInfo?.feeMultiplier).to.be.equal(0);
+
         transaction = await firstValueFrom(transactionHttp.getTransaction(generationHash, TransactionGroup.Unconfirmed));
 
         expect(transaction.type.valueOf()).to.be.equal(TransactionType.TRANSFER.valueOf());
         expect(((transaction as TransferTransaction).recipientAddress as Address).plain()).to.be.equal(TestAddress.plain());
         expect(transaction.transactionInfo?.id).to.be.equal('id');
         expect(transaction.transactionInfo?.hash).to.be.equal('hash');
+        expect(transaction.transactionInfo?.timestamp?.toString()).to.be.equal('0');
+        expect(transaction.transactionInfo?.feeMultiplier).to.be.equal(0);
     });
 
     it('Test getTransactionsById method', async () => {
@@ -274,8 +304,6 @@ describe('TransactionHttp', () => {
         metaDto.hash = 'hash';
         metaDto.height = '1';
         metaDto.index = 0;
-        metaDto.timestamp = '0';
-        metaDto.feeMultiplier = 0;
         metaDto.merkleComponentHash = 'merkleHash';
 
         const transactionDto = {} as TransferTransactionDTO;
@@ -292,7 +320,17 @@ describe('TransactionHttp', () => {
         transactionInfoDto.transaction = transactionDto;
 
         when(transactionRoutesApi.getConfirmedTransactions(deepEqual({ transactionIds: [generationHash] }))).thenReturn(
-            Promise.resolve([transactionInfoDto]),
+            Promise.resolve([
+                {
+                    id: 'id',
+                    meta: {
+                        ...metaDto,
+                        feeMultiplier: 100,
+                        timestamp: '1000',
+                    },
+                    transaction: transactionDto,
+                },
+            ]),
         );
 
         const transactionConfirmed = await firstValueFrom(
@@ -318,20 +356,24 @@ describe('TransactionHttp', () => {
         expect(((transactionConfirmed[0] as TransferTransaction).recipientAddress as Address).plain()).to.be.equal(TestAddress.plain());
         expect(transactionConfirmed[0].transactionInfo?.id).to.be.equal('id');
         expect(transactionConfirmed[0].transactionInfo?.hash).to.be.equal('hash');
-        expect(transactionConfirmed[0].transactionInfo?.timestamp?.toString()).to.be.equal('0');
-        expect(transactionConfirmed[0].transactionInfo?.feeMultiplier).to.be.equal(0);
+        expect(transactionConfirmed[0].transactionInfo?.timestamp?.toString()).to.be.equal('1000');
+        expect(transactionConfirmed[0].transactionInfo?.feeMultiplier).to.be.equal(100);
 
         expect(transactionUnconfirmed.length).to.be.equal(1);
         expect(transactionUnconfirmed[0].type.valueOf()).to.be.equal(TransactionType.TRANSFER.valueOf());
         expect(((transactionUnconfirmed[0] as TransferTransaction).recipientAddress as Address).plain()).to.be.equal(TestAddress.plain());
         expect(transactionUnconfirmed[0].transactionInfo?.id).to.be.equal('id');
         expect(transactionUnconfirmed[0].transactionInfo?.hash).to.be.equal('hash');
+        expect(transactionUnconfirmed[0].transactionInfo?.timestamp?.toString()).to.be.equal('0');
+        expect(transactionUnconfirmed[0].transactionInfo?.feeMultiplier).to.be.equal(0);
 
         expect(transactionPartial.length).to.be.equal(1);
         expect(transactionPartial[0].type.valueOf()).to.be.equal(TransactionType.TRANSFER.valueOf());
         expect(((transactionPartial[0] as TransferTransaction).recipientAddress as Address).plain()).to.be.equal(TestAddress.plain());
         expect(transactionPartial[0].transactionInfo?.id).to.be.equal('id');
         expect(transactionPartial[0].transactionInfo?.hash).to.be.equal('hash');
+        expect(transactionPartial[0].transactionInfo?.timestamp?.toString()).to.be.equal('0');
+        expect(transactionPartial[0].transactionInfo?.feeMultiplier).to.be.equal(0);
     });
 
     it('Test getEffectiveFees method', async () => {


### PR DESCRIPTION
Releasing `v2.0.2`.

## CHANGELOG:
## [2.0.2] - 07-Oct-2022

**Milestone**: Symbol Mainnet
Package  | Version  | Link
---|---|---
SDK Core| v2.0.2 | [symbol-sdk](https://www.npmjs.com/package/symbol-sdk)
Catbuffer | v1.0.1 | [catbuffer-typescript](https://www.npmjs.com/package/catbuffer-typescript)
Client Library | v1.0.3  | [symbol-openapi-typescript-fetch-client](https://www.npmjs.com/package/symbol-openapi-typescript-fetch-client)

[Bug] [#843](https://github.com/symbol/symbol-sdk-typescript-javascript/pull/843): Handle transaction meta's timestamp and feeMultiplier when value is undefined.