### PR TITLE
Release v2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 
 ## 2.0.3 - 25-Oct-2022
 
-**Milestone**: Symbol Mainnet
 Package  | Version  | Link
 ---|---|---
 SDK Core| v2.0.3 | [symbol-sdk](https://www.npmjs.com/package/symbol-sdk)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.0.3 - 25-Oct-2022
+
+**Milestone**: Symbol Mainnet
+Package  | Version  | Link
+---|---|---
+SDK Core| v2.0.3 | [symbol-sdk](https://www.npmjs.com/package/symbol-sdk)
+Catbuffer | v1.0.2 | [catbuffer-typescript](https://www.npmjs.com/package/catbuffer-typescript)
+Client Library | v1.0.3  | [symbol-openapi-typescript-fetch-client](https://www.npmjs.com/package/symbol-openapi-typescript-fetch-client)
+
+- Bumped AggregateTransaction version to V2. Note that the ability to create or broadcast V1 aggregate transactions has been removed.
+- [Bug] Fixed incorrect Merkle hash calculation for aggregate transactions.
+- [Bug] Fixed the calculation of embedded transaction (also known as inner aggregate transaction) hashes without padding.
+
 ## 2.0.2 - 7-Oct-2022
 
 **Milestone**: Symbol Mainnet

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "@js-joda/core": "^3.2.0",
-                "catbuffer-typescript": "^1.0.1",
+                "catbuffer-typescript": "^1.0.2",
                 "crypto-js": "^4.0.0",
                 "futoin-hkdf": "^1.3.2",
                 "js-sha256": "^0.9.0",
@@ -1657,9 +1657,9 @@
             "dev": true
         },
         "node_modules/catbuffer-typescript": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/catbuffer-typescript/-/catbuffer-typescript-1.0.1.tgz",
-            "integrity": "sha512-IyC2bmBEMRY96/NMsAer+qMTSa6yAwKfGIbpYPDPnlSb4UguNOlSabbCFH0CDQfhWuO6wqH97xGCuB4qY3OCwA=="
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/catbuffer-typescript/-/catbuffer-typescript-1.0.2.tgz",
+            "integrity": "sha512-wFcpz5A9H1jqVyfaTv596V3X19b1iBfz25CPAesQjtFDVq2zY0G2HvoYldggqlkmqNbkFaz5TICkKRsWgn9dyQ=="
         },
         "node_modules/chai": {
             "version": "4.2.0",
@@ -8134,9 +8134,9 @@
             "dev": true
         },
         "catbuffer-typescript": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/catbuffer-typescript/-/catbuffer-typescript-1.0.1.tgz",
-            "integrity": "sha512-IyC2bmBEMRY96/NMsAer+qMTSa6yAwKfGIbpYPDPnlSb4UguNOlSabbCFH0CDQfhWuO6wqH97xGCuB4qY3OCwA=="
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/catbuffer-typescript/-/catbuffer-typescript-1.0.2.tgz",
+            "integrity": "sha512-wFcpz5A9H1jqVyfaTv596V3X19b1iBfz25CPAesQjtFDVq2zY0G2HvoYldggqlkmqNbkFaz5TICkKRsWgn9dyQ=="
         },
         "chai": {
             "version": "4.2.0",


### PR DESCRIPTION
Releasing v2.0.3

## 2.0.3 - 25-Oct-2022

**Milestone**: Symbol Mainnet
Package  | Version  | Link
---|---|---
SDK Core| v2.0.3 | [symbol-sdk](https://www.npmjs.com/package/symbol-sdk)
Catbuffer | v1.0.2 | [catbuffer-typescript](https://www.npmjs.com/package/catbuffer-typescript)
Client Library | v1.0.3  | [symbol-openapi-typescript-fetch-client](https://www.npmjs.com/package/symbol-openapi-typescript-fetch-client)

- Bumped AggregateTransaction version to V2. Note that the ability to create or broadcast V1 aggregate transactions has been removed.
- [Bug] Fixed incorrect Merkle hash calculation for aggregate transactions.
- [Bug] Fixed the calculation of embedded transaction (also known as inner aggregate transaction) hashes without padding.
