### PR TITLE
Fix mosaic definition transaction from payload method

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,4 +82,4 @@ Then sit back and wait. There will probably be discussion about the pull request
 *CONTRIBUTING.md is based on [CONTRIBUTING-template.md](https://github.com/nayafia/contributing-template/blob/master/CONTRIBUTING-template.md)* , [elasticsearch/CONTRIBUTING](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md) and [spark/CONTRIBUTING](https://github.com/apache/spark/blob/master/CONTRIBUTING.md)
 
 [pull-request]: https://help.github.com/articles/about-pull-requests/
-[github-issues]: https://github.com/nemtech/symbol-sdk-typescript-javascript/issues
+[github-issues]: https://github.com/symbol/symbol-sdk-typescript-javascript/issues

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ The Symbol SDK for TypeScript / JavaScript allows you to develop web, mobile, an
 
 ## Important Notes
 
-### _Catapult-Server_ Network Compatibility (catapult-server@0.10.0.8)
+### _Catapult-Server_ Network Compatibility (catapult-server@1.0.3.5)
 
-Symbol network launched [catapult-client](https://github.com/symbol/catapult-client/releases/tag/v1.0.0.0), **it is recommended to use this package's 1.0.0 version and upwards for the Symbol public network**.
+Symbol network launched [catapult-client](https://github.com/symbol/symbol/releases), **it is recommended to use this package's 2.0.3 version and upwards for the Symbol public network**.
 
 Find the complete release notes [here](CHANGELOG.md).
 
@@ -58,8 +58,8 @@ Copyright (c) 2018-present NEM
 Licensed under the [Apache License 2.0](LICENSE)
 
 [self]: https://github.com/symbol/symbol-sdk-typescript-javascript
-[docs]: http://docs.symbolplatform.com/getting-started/setup-workstation.html
+[docs]: https://docs.symbol.dev/getting-started/setup-workstation.html
 [issues]: https://github.com/symbol/symbol-sdk-typescript-javascript/issues
-[sdk-ref]: https://docs.symbolplatform.com/references/typescript-sdk.html
-[guidelines]: https://docs.symbolplatform.com/contribute/contributing.html#sdk
+[sdk-ref]: https://docs.symbol.dev/references/typescript-sdk.html
+[guidelines]: https://docs.symbol.dev/contribute/contributing.html#sdk
 [discord]: https://discord.com/invite/xymcity

--- a/src/model/mosaic/MosaicInfo.ts
+++ b/src/model/mosaic/MosaicInfo.ts
@@ -114,6 +114,14 @@ export class MosaicInfo {
     }
 
     /**
+     * Is revokable
+     * @returns {boolean}
+     */
+    public isRevokable(): boolean {
+        return this.flags.revokable;
+    }
+
+    /**
      * Generate buffer
      * @return {Uint8Array}
      */

--- a/src/model/transaction/MosaicDefinitionTransaction.ts
+++ b/src/model/transaction/MosaicDefinitionTransaction.ts
@@ -156,6 +156,7 @@ export class MosaicDefinitionTransaction extends Transaction {
                 builder.getFlags().indexOf(MosaicFlagsDto.SUPPLY_MUTABLE) > -1,
                 builder.getFlags().indexOf(MosaicFlagsDto.TRANSFERABLE) > -1,
                 builder.getFlags().indexOf(MosaicFlagsDto.RESTRICTABLE) > -1,
+                builder.getFlags().indexOf(MosaicFlagsDto.REVOKABLE) > -1,
             ),
             builder.getDivisibility(),
             new UInt64(builder.getDuration().blockDuration),

--- a/test/model/transaction/MosaicDefinitionTransaction.spec.ts
+++ b/test/model/transaction/MosaicDefinitionTransaction.spec.ts
@@ -15,6 +15,7 @@
  */
 
 import { expect } from 'chai';
+import { CreateTransactionFromPayload } from '../../../src';
 import { Convert } from '../../../src/core/format';
 import { Account } from '../../../src/model/account/Account';
 import { MosaicFlags } from '../../../src/model/mosaic/MosaicFlags';
@@ -198,5 +199,25 @@ describe('MosaicDefinitionTransaction', () => {
 
         Object.assign(tx, { signer: account.publicAccount });
         expect(tx.shouldNotifyAccount(account.address)).to.be.true;
+    });
+
+    it('should set correctly revokable flag when generating transaction from payload', () => {
+        const mosaicDefinitionTransaction = MosaicDefinitionTransaction.create(
+            Deadline.create(epochAdjustment),
+            MosaicNonce.createFromUint8Array(new Uint8Array([0xe6, 0xde, 0x84, 0xb8])),
+            new MosaicId(UInt64.fromUint(1).toDTO()),
+            MosaicFlags.create(false, false, false, true),
+            3,
+            UInt64.fromUint(0),
+            TestNetworkType,
+        );
+
+        const signedTransaction = mosaicDefinitionTransaction.signWith(account, generationHash);
+        const recreatedTransaction = CreateTransactionFromPayload(signedTransaction.payload) as MosaicDefinitionTransaction;
+
+        expect(recreatedTransaction.flags.supplyMutable).to.be.equal(false);
+        expect(recreatedTransaction.flags.transferable).to.be.equal(false);
+        expect(recreatedTransaction.flags.restrictable).to.be.equal(false);
+        expect(recreatedTransaction.flags.revokable).to.be.equal(true);
     });
 });


### PR DESCRIPTION
### What was the issue?

The revocable attribute is missing when generating a MethodDefinitionTransaction from a payload. Check #849

### What's the fix?

MethodDefinitionTransaction is initializing now all mosaic flags when creating MosaicDefinitionTransaction from the payload.