### PR TITLE
Release v2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.0.5 - 15-Mar-2024
+
+Package  | Version  | Link
+---|---|---
+SDK Core| v2.0.5 | [symbol-sdk](https://www.npmjs.com/package/symbol-sdk)
+Catbuffer | v1.0.2 | [catbuffer-typescript](https://www.npmjs.com/package/catbuffer-typescript)
+Client Library | v1.0.3  | [symbol-openapi-typescript-fetch-client](https://www.npmjs.com/package/symbol-openapi-typescript-fetch-client)
+
+- [Bug] [853](https://github.com/symbol/symbol-sdk-typescript-javascript/pull/853): Fixed encoding of raw messages in TransferTransaction.
+
 ## 2.0.4 - 7-Mar-2023
 
 Package  | Version  | Link

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "symbol-sdk",
-    "version": "2.0.4",
+    "version": "2.0.5",
     "description": "Reactive symbol sdk for typescript and javascript",
     "scripts": {
         "pretest": "npm run build",

--- a/src/model/transaction/TransferTransaction.ts
+++ b/src/model/transaction/TransferTransaction.ts
@@ -202,13 +202,15 @@ export class TransferTransaction extends Transaction {
         if (!this.message || !this.message.payload) {
             return Uint8Array.of();
         }
-        const messgeHex =
-            this.message.type === MessageType.PersistentHarvestingDelegationMessage
-                ? this.message.payload
-                : Convert.utf8ToHex(this.message.payload);
-        const payloadBuffer = Convert.hexToUint8(messgeHex);
+        const isPersistentHarvestingDelegationMessage = this.message.type === MessageType.PersistentHarvestingDelegationMessage;
+        const isRawMessage = this.message.type === MessageType.RawMessage;
+
+        const messageHex =
+            isPersistentHarvestingDelegationMessage || isRawMessage ? this.message.payload : Convert.utf8ToHex(this.message.payload);
+        const payloadBuffer = Convert.hexToUint8(messageHex);
         const typeBuffer = GeneratorUtils.uintToBuffer(this.message.type, 1);
-        return this.message.type === MessageType.PersistentHarvestingDelegationMessage || !this.message.payload
+
+        return isPersistentHarvestingDelegationMessage || isRawMessage || !this.message.payload
             ? payloadBuffer
             : GeneratorUtils.concatTypedArrays(typeBuffer, payloadBuffer);
     }

--- a/test/model/transaction/TransferTransaction.spec.ts
+++ b/test/model/transaction/TransferTransaction.spec.ts
@@ -21,7 +21,7 @@ import { TransactionMapping } from '../../../src/core/utils';
 import { CreateTransactionFromPayload } from '../../../src/infrastructure/transaction';
 import { PersistentHarvestingDelegationMessage, UInt64 } from '../../../src/model';
 import { Account, Address } from '../../../src/model/account';
-import { EmptyMessage, MessageMarker, MessageType, PlainMessage } from '../../../src/model/message';
+import { EmptyMessage, MessageMarker, MessageType, PlainMessage, RawMessage } from '../../../src/model/message';
 import { Mosaic, MosaicId } from '../../../src/model/mosaic';
 import { NamespaceId } from '../../../src/model/namespace';
 import { NetworkType } from '../../../src/model/network';
@@ -131,6 +131,29 @@ describe('TransferTransaction', () => {
         expect(signedTransaction.payload.substring(256, signedTransaction.payload.length)).to.be.equal(
             '9826D27E1D0A26CA4E316F901E23E55C8711DB20DFD267760000000000000000',
         );
+    });
+
+    it('should createComplete an TransferTransaction object with raw message', () => {
+        // Arrange:
+        const messageBytes = new Uint8Array([3, 2, 1, 123, 0, 255]);
+        const messageHex = '0302017B00FF';
+
+        // Act:
+        const transferTransaction = TransferTransaction.create(
+            Deadline.create(epochAdjustment),
+            testAddress,
+            [],
+            RawMessage.create(messageBytes),
+            TestNetworkType,
+        );
+        const transactionPayload = transferTransaction.signWith(account, generationHash).payload;
+        const recreatedTransferTransaction = TransferTransaction.createFromPayload(transactionPayload) as TransferTransaction;
+
+        // Assert:
+        expect(transferTransaction.message.type).to.be.equal(MessageType.RawMessage);
+        expect(transferTransaction.message.payload).to.be.equal(messageHex);
+        expect(recreatedTransferTransaction.message.type).to.be.equal(MessageType.RawMessage);
+        expect(recreatedTransferTransaction.message.payload).to.be.equal(messageHex);
     });
 
     it('should createComplete an TransferTransaction object and sign it with mosaics', () => {


### PR DESCRIPTION
## 2.0.5 - 15-Mar-2024

Package  | Version  | Link
---|---|---
SDK Core| v2.0.5 | [symbol-sdk](https://www.npmjs.com/package/symbol-sdk)
Catbuffer | v1.0.2 | [catbuffer-typescript](https://www.npmjs.com/package/catbuffer-typescript)
Client Library | v1.0.3  | [symbol-openapi-typescript-fetch-client](https://www.npmjs.com/package/symbol-openapi-typescript-fetch-client)

- [Bug] [853](https://github.com/symbol/symbol-sdk-typescript-javascript/pull/853): Fixed encoding of raw messages in TransferTransaction.